### PR TITLE
Add zwlr_layer_shell_v1 support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+	nativeBuildInputs = with pkgs.buildPackages; [
+		clang
+		gnumake
+		pkg-config
+		bear
+		
+		xorg.libX11
+		xorg.libXcursor.dev
+		xorg.libXrender
+		xorg.libXext
+		libxkbcommon
+		libGL.dev
+		wayland
+		wayland-protocols
+		wayland-scanner.dev
+	];
+}

--- a/src/siwin/platforms.nim
+++ b/src/siwin/platforms.nim
@@ -32,7 +32,7 @@ proc availablePlatforms*: seq[Platform] =
   elif defined(linux):
     waylandGlobals.init()
     # todo: detect if x11 is really available
-    
+
     if waylandGlobals.waylandAvailable:
       @[Platform.wayland, Platform.x11]
     else:

--- a/src/siwin/platforms/wayland/globals.nim
+++ b/src/siwin/platforms/wayland/globals.nim
@@ -20,6 +20,7 @@ var
 
   serverDecorationManager*: Zxdg_decoration_manager_v1
   plasmaShell*: Org_kde_plasma_shell
+  layerShell*: Zwlr_layer_shell_v1
   
   shmFormats*: seq[`WlShm / Format`]
   seatCapabilities*: Bitfield[`WlSeat / Capability`]
@@ -71,10 +72,11 @@ addRegistry Wl_seat:
 addRegistry Zxdg_decoration_manager_v1:
   serverDecorationManager = binded
 
-
 addRegistry Org_kde_plasma_shell:
   plasmaShell = binded
 
+addRegistry Zwlr_layer_shell_v1:
+  layerShell = binded
 
 proc init* =
   if initialized: return

--- a/src/siwin/platforms/wayland/libwayland.nim
+++ b/src/siwin/platforms/wayland/libwayland.nim
@@ -24,6 +24,23 @@ type
     eventsLen*: int32
     events*: ptr UncheckedArray[WlMessage]
 
+  Layer* {.pure.} = enum
+    Background = 0
+    Bottom = 1
+    Top = 2
+    Overlay = 3
+
+  LayerInteractivityMode* {.pure.} = enum
+    None
+    Exclusive
+    OnDemand
+
+  LayerEdge* {.pure.} = enum
+    Top = 1
+    Bottom = 2
+    Left = 4
+    Right = 8
+
   WlMessage* = object
     name*: cstring
     signature*: cstring
@@ -40,6 +57,8 @@ type
     types*: ptr UncheckedArray[ptr Wl_interface]
   
   WaylandProtocolError* = object of CatchableError
+
+  RoundtripFailed* = object of WaylandProtocolError
 
   Wl_dispatcher_proc* = proc(
       impl: pointer, obj: pointer, opcode: uint32, msg: ptr WlMessage, args: pointer

--- a/src/siwin/platforms/wayland/protocol_generated.nim
+++ b/src/siwin/platforms/wayland/protocol_generated.nim
@@ -6,297 +6,58 @@ import
   libwayland
 
 type
-  Zwp_tablet_manager_v2* = object
-    ## An object that provides access to the graphics tablets available on this
-    ## system. All tablets are associated with a seat, to get access to the
-    ## actual tablets, use wp_tablet_manager.get_tablet_seat.
+  Zwlr_layer_shell_v1* = object
+    ## Clients can use this interface to assign the surface_layer role to
+    ## wl_surfaces. Such surfaces are assigned to a "layer" of the output and
+    ## rendered with a defined z-depth respective to each other. They may also be
+    ## anchored to the edges and corners of a screen and specify input handling
+    ## semantics. This interface should be suitable for the implementation of
+    ## many desktop shell components, and a broad number of other applications
+    ## that interact with the desktop.
     proxy*: Wl_proxy
-
-  `Zwp_tablet_manager_v2 / Callbacks`* = object
+  `Zwlr_layer_shell_v1 / Error`* {.size: 4.} = enum
+    role = 0, invalid_layer = 1, already_constructed = 2
+  `Zwlr_layer_shell_v1 / Layer`* {.size: 4.} = enum ## These values indicate which layers a surface can be rendered in. They
+                                                     ## are ordered by z depth, bottom-most first. Traditional shell surfaces
+                                                     ## will typically be rendered between the bottom and top layers.
+                                                     ## Fullscreen shell surfaces are typically rendered at the top layer.
+                                                     ## Multiple surfaces can share a single layer, and ordering within a
+                                                     ## single layer is undefined.
+    background = 0, bottom = 1, top = 2, overlay = 3
+  `Zwlr_layer_shell_v1 / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
-  Zwp_tablet_seat_v2* = object
-    ## An object that provides access to the graphics tablets available on this
-    ## seat. After binding to this interface, the compositor sends a set of
-    ## wp_tablet_seat.tablet_added and wp_tablet_seat.tool_added events.
+  Zwlr_layer_surface_v1* = object
+    ## An interface that may be implemented by a wl_surface, for surfaces that
+    ## are designed to be rendered as a layer of a stacked desktop-like
+    ## environment.
+    ## 
+    ## Layer surface state (layer, size, anchor, exclusive zone,
+    ## margin, interactivity) is double-buffered, and will be applied at the
+    ## time wl_surface.commit of the corresponding wl_surface is called.
+    ## 
+    ## Attaching a null buffer to a layer surface unmaps it.
+    ## 
+    ## Unmapping a layer_surface means that the surface cannot be shown by the
+    ## compositor until it is explicitly mapped again. The layer_surface
+    ## returns to the state it had right after layer_shell.get_layer_surface.
+    ## The client can re-map the surface by performing a commit without any
+    ## buffer attached, waiting for a configure event and handling it as usual.
     proxy*: Wl_proxy
-
-  `Zwp_tablet_seat_v2 / Callbacks`* = object
+  `Zwlr_layer_surface_v1 / Keyboard_interactivity`* {.size: 4.} = enum ## Types of keyboard interaction possible for layer shell surfaces. The
+                                                                        ## rationale for this is twofold: (1) some applications are not interested
+                                                                        ## in keyboard events and not allowing them to be focused can improve the
+                                                                        ## desktop experience; (2) some applications will want to take exclusive
+                                                                        ## keyboard focus.
+    none = 0, exclusive = 1, on_demand = 2
+  `Zwlr_layer_surface_v1 / Error`* {.size: 4.} = enum
+    invalid_surface_state = 0, invalid_size = 1, invalid_anchor = 2,
+    invalid_keyboard_interactivity = 3
+  `Zwlr_layer_surface_v1 / Anchor`* {.size: 4.} = enum
+    top = 1, bottom = 2, left = 4, right = 8
+  `Zwlr_layer_surface_v1 / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    tablet_added*: proc (id: Zwp_tablet_v2)
-    tool_added*: proc (id: Zwp_tablet_tool_v2)
-    pad_added*: proc (id: Zwp_tablet_pad_v2)
-
-  Zwp_tablet_tool_v2* = object
-    ## An object that represents a physical tool that has been, or is
-    ## currently in use with a tablet in this seat. Each wp_tablet_tool
-    ## object stays valid until the client destroys it; the compositor
-    ## reuses the wp_tablet_tool object to indicate that the object's
-    ## respective physical tool has come into proximity of a tablet again.
-    ## 
-    ## A wp_tablet_tool object's relation to a physical tool depends on the
-    ## tablet's ability to report serial numbers. If the tablet supports
-    ## this capability, then the object represents a specific physical tool
-    ## and can be identified even when used on multiple tablets.
-    ## 
-    ## A tablet tool has a number of static characteristics, e.g. tool type,
-    ## hardware_serial and capabilities. These capabilities are sent in an
-    ## event sequence after the wp_tablet_seat.tool_added event before any
-    ## actual events from this tool. This initial event sequence is
-    ## terminated by a wp_tablet_tool.done event.
-    ## 
-    ## Tablet tool events are grouped by wp_tablet_tool.frame events.
-    ## Any events received before a wp_tablet_tool.frame event should be
-    ## considered part of the same hardware state change.
-    proxy*: Wl_proxy
-
-  `Zwp_tablet_tool_v2 / Type`* {.size: 4.} = enum ## Describes the physical type of a tool. The physical type of a tool
-                                                   ## generally defines its base usage.
-                                                   ## 
-                                                   ## The mouse tool represents a mouse-shaped tool that is not a relative
-                                                   ## device but bound to the tablet's surface, providing absolute
-                                                   ## coordinates.
-                                                   ## 
-                                                   ## The lens tool is a mouse-shaped tool with an attached lens to
-                                                   ## provide precision focus.
-    pen = 320, eraser = 321, brush = 322, pencil = 323, airbrush = 324,
-    finger = 325, mouse = 326, lens = 327
-  `Zwp_tablet_tool_v2 / Capability`* {.size: 4.} = enum ## Describes extra capabilities on a tablet.
-                                                         ## 
-                                                         ## Any tool must provide x and y values, extra axes are
-                                                         ## device-specific.
-    tilt = 1, pressure = 2, distance = 3, rotation = 4, slider = 5, wheel = 6
-  `Zwp_tablet_tool_v2 / Button_state`* {.size: 4.} = enum ## Describes the physical state of a button that produced the button event.
-    released = 0, pressed = 1
-  `Zwp_tablet_tool_v2 / Error`* {.size: 4.} = enum
-    role = 0
-  `Zwp_tablet_tool_v2 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    `type`*: proc (tool_type: `Zwp_tablet_tool_v2 / Type`)
-    hardware_serial*: proc (hardware_serial_hi: uint32;
-                            hardware_serial_lo: uint32)
-    hardware_id_wacom*: proc (hardware_id_hi: uint32; hardware_id_lo: uint32)
-    capability*: proc (capability: `Zwp_tablet_tool_v2 / Capability`)
-    done*: proc ()
-    removed*: proc ()
-    proximity_in*: proc (serial: uint32; tablet: Zwp_tablet_v2;
-                         surface: Wl_surface)
-    proximity_out*: proc ()
-    down*: proc (serial: uint32)
-    up*: proc ()
-    motion*: proc (x: float32; y: float32)
-    pressure*: proc (pressure: uint32)
-    distance*: proc (distance: uint32)
-    tilt*: proc (tilt_x: float32; tilt_y: float32)
-    rotation*: proc (degrees: float32)
-    slider*: proc (position: int32)
-    wheel*: proc (degrees: float32; clicks: int32)
-    button*: proc (serial: uint32; button: uint32;
-                   state: `Zwp_tablet_tool_v2 / Button_state`)
-    frame*: proc (time: uint32)
-
-  Zwp_tablet_v2* = object
-    ## The wp_tablet interface represents one graphics tablet device. The
-    ## tablet interface itself does not generate events; all events are
-    ## generated by wp_tablet_tool objects when in proximity above a tablet.
-    ## 
-    ## A tablet has a number of static characteristics, e.g. device name and
-    ## pid/vid. These capabilities are sent in an event sequence after the
-    ## wp_tablet_seat.tablet_added event. This initial event sequence is
-    ## terminated by a wp_tablet.done event.
-    proxy*: Wl_proxy
-
-  `Zwp_tablet_v2 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    name*: proc (name: cstring)
-    id*: proc (vid: uint32; pid: uint32)
-    path*: proc (path: cstring)
-    done*: proc ()
-    removed*: proc ()
-
-  Zwp_tablet_pad_ring_v2* = object
-    ## A circular interaction area, such as the touch ring on the Wacom Intuos
-    ## Pro series tablets.
-    ## 
-    ## Events on a ring are logically grouped by the wl_tablet_pad_ring.frame
-    ## event.
-    proxy*: Wl_proxy
-
-  `Zwp_tablet_pad_ring_v2 / Source`* {.size: 4.} = enum ## Describes the source types for ring events. This indicates to the
-                                                         ## client how a ring event was physically generated; a client may
-                                                         ## adjust the user interface accordingly. For example, events
-                                                         ## from a "finger" source may trigger kinetic scrolling.
-    finger = 1
-  `Zwp_tablet_pad_ring_v2 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    source*: proc (source: `Zwp_tablet_pad_ring_v2 / Source`)
-    angle*: proc (degrees: float32)
-    stop*: proc ()
-    frame*: proc (time: uint32)
-
-  Zwp_tablet_pad_strip_v2* = object
-    ## A linear interaction area, such as the strips found in Wacom Cintiq
-    ## models.
-    ## 
-    ## Events on a strip are logically grouped by the wl_tablet_pad_strip.frame
-    ## event.
-    proxy*: Wl_proxy
-
-  `Zwp_tablet_pad_strip_v2 / Source`* {.size: 4.} = enum ## Describes the source types for strip events. This indicates to the
-                                                          ## client how a strip event was physically generated; a client may
-                                                          ## adjust the user interface accordingly. For example, events
-                                                          ## from a "finger" source may trigger kinetic scrolling.
-    finger = 1
-  `Zwp_tablet_pad_strip_v2 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    source*: proc (source: `Zwp_tablet_pad_strip_v2 / Source`)
-    position*: proc (position: uint32)
-    stop*: proc ()
-    frame*: proc (time: uint32)
-
-  Zwp_tablet_pad_group_v2* = object
-    ## A pad group describes a distinct (sub)set of buttons, rings and strips
-    ## present in the tablet. The criteria of this grouping is usually positional,
-    ## eg. if a tablet has buttons on the left and right side, 2 groups will be
-    ## presented. The physical arrangement of groups is undisclosed and may
-    ## change on the fly.
-    ## 
-    ## Pad groups will announce their features during pad initialization. Between
-    ## the corresponding wp_tablet_pad.group event and wp_tablet_pad_group.done, the
-    ## pad group will announce the buttons, rings and strips contained in it,
-    ## plus the number of supported modes.
-    ## 
-    ## Modes are a mechanism to allow multiple groups of actions for every element
-    ## in the pad group. The number of groups and available modes in each is
-    ## persistent across device plugs. The current mode is user-switchable, it
-    ## will be announced through the wp_tablet_pad_group.mode_switch event both
-    ## whenever it is switched, and after wp_tablet_pad.enter.
-    ## 
-    ## The current mode logically applies to all elements in the pad group,
-    ## although it is at clients' discretion whether to actually perform different
-    ## actions, and/or issue the respective .set_feedback requests to notify the
-    ## compositor. See the wp_tablet_pad_group.mode_switch event for more details.
-    proxy*: Wl_proxy
-
-  `Zwp_tablet_pad_group_v2 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    buttons*: proc (buttons: Wl_array)
-    ring*: proc (ring: Zwp_tablet_pad_ring_v2)
-    strip*: proc (strip: Zwp_tablet_pad_strip_v2)
-    modes*: proc (modes: uint32)
-    done*: proc ()
-    mode_switch*: proc (time: uint32; serial: uint32; mode: uint32)
-
-  Zwp_tablet_pad_v2* = object
-    ## A pad device is a set of buttons, rings and strips
-    ## usually physically present on the tablet device itself. Some
-    ## exceptions exist where the pad device is physically detached, e.g. the
-    ## Wacom ExpressKey Remote.
-    ## 
-    ## Pad devices have no axes that control the cursor and are generally
-    ## auxiliary devices to the tool devices used on the tablet surface.
-    ## 
-    ## A pad device has a number of static characteristics, e.g. the number
-    ## of rings. These capabilities are sent in an event sequence after the
-    ## wp_tablet_seat.pad_added event before any actual events from this pad.
-    ## This initial event sequence is terminated by a wp_tablet_pad.done
-    ## event.
-    ## 
-    ## All pad features (buttons, rings and strips) are logically divided into
-    ## groups and all pads have at least one group. The available groups are
-    ## notified through the wp_tablet_pad.group event; the compositor will
-    ## emit one event per group before emitting wp_tablet_pad.done.
-    ## 
-    ## Groups may have multiple modes. Modes allow clients to map multiple
-    ## actions to a single pad feature. Only one mode can be active per group,
-    ## although different groups may have different active modes.
-    proxy*: Wl_proxy
-
-  `Zwp_tablet_pad_v2 / Button_state`* {.size: 4.} = enum ## Describes the physical state of a button that caused the button
-                                                          ## event.
-    released = 0, pressed = 1
-  `Zwp_tablet_pad_v2 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    group*: proc (pad_group: Zwp_tablet_pad_group_v2)
-    path*: proc (path: cstring)
-    buttons*: proc (buttons: uint32)
-    done*: proc ()
-    button*: proc (time: uint32; button: uint32;
-                   state: `Zwp_tablet_pad_v2 / Button_state`)
-    enter*: proc (serial: uint32; tablet: Zwp_tablet_v2; surface: Wl_surface)
-    leave*: proc (serial: uint32; surface: Wl_surface)
-    removed*: proc ()
-
-  Org_kde_plasma_shell* = object
-    ## This interface is used by KF5 powered Wayland shells to communicate with
-    ## the compositor and can only be bound one time.
-    proxy*: Wl_proxy
-
-  `Org_kde_plasma_shell / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
-  Org_kde_plasma_surface* = object
-    ## An interface that may be implemented by a wl_surface, for
-    ## implementations that provide the shell user interface.
-    ## 
-    ## It provides requests to set surface roles, assign an output
-    ## or set the position in output coordinates.
-    ## 
-    ## On the server side the object is automatically destroyed when
-    ## the related wl_surface is destroyed.  On client side,
-    ## org_kde_plasma_surface.destroy() must be called before
-    ## destroying the wl_surface object.
-    proxy*: Wl_proxy
-
-  `Org_kde_plasma_surface / Role`* {.size: 4.} = enum
-    normal = 0, desktop = 1, panel = 2, onscreendisplay = 3, notification = 4,
-    tooltip = 5, criticalnotification = 6, appletpopup = 7
-  `Org_kde_plasma_surface / Panel_behavior`* {.size: 4.} = enum ## Behavior for panel surface
-    always_visible = 1, auto_hide = 2, windows_can_cover = 3,
-    windows_go_below = 4
-  `Org_kde_plasma_surface / Error`* {.size: 4.} = enum
-    panel_not_auto_hide = 0
-  `Org_kde_plasma_surface / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-    auto_hidden_panel_hidden*: proc ()
-    auto_hidden_panel_shown*: proc ()
-
-  Wp_cursor_shape_manager_v1* = object
-    ## This global offers an alternative, optional way to set cursor images. This
-    ## new way uses enumerated cursors instead of a wl_surface like
-    ## wl_pointer.set_cursor does.
-    ## 
-    ## Warning! The protocol described in this file is currently in the testing
-    ## phase. Backward compatible changes may be added together with the
-    ## corresponding interface version bump. Backward incompatible changes can
-    ## only be done by creating a new major version of the extension.
-    proxy*: Wl_proxy
-
-  `Wp_cursor_shape_manager_v1 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
-  Wp_cursor_shape_device_v1* = object
-    ## This interface advertises the list of supported cursor shapes for a
-    ## device, and allows clients to set the cursor shape.
-    proxy*: Wl_proxy
-
-  `Wp_cursor_shape_device_v1 / Shape`* {.size: 4.} = enum ## This enum describes cursor shapes.
-                                                           ## 
-                                                           ## The names are taken from the CSS W3C specification:
-                                                           ## https://w3c.github.io/csswg-drafts/css-ui/#cursor
-    default = 1, context_menu = 2, help = 3, pointer = 4, progress = 5,
-    wait = 6, cell = 7, crosshair = 8, text = 9, vertical_text = 10, alias = 11,
-    copy = 12, move = 13, no_drop = 14, not_allowed = 15, grab = 16,
-    grabbing = 17, e_resize = 18, n_resize = 19, ne_resize = 20, nw_resize = 21,
-    s_resize = 22, se_resize = 23, sw_resize = 24, w_resize = 25,
-    ew_resize = 26, ns_resize = 27, nesw_resize = 28, nwse_resize = 29,
-    col_resize = 30, row_resize = 31, all_scroll = 32, zoom_in = 33,
-    zoom_out = 34
-  `Wp_cursor_shape_device_v1 / Error`* {.size: 4.} = enum
-    invalid_shape = 1
-  `Wp_cursor_shape_device_v1 / Callbacks`* = object
-    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
+    configure*: proc (serial: uint32; width: uint32; height: uint32)
+    closed*: proc ()
   Xdg_wm_base* = object
     ## The xdg_wm_base interface is exposed as a global object enabling clients
     ## to turn their wl_surfaces into windows in a desktop environment. It
@@ -304,7 +65,6 @@ type
     ## create windows that can be dragged, resized, maximized, etc, as well as
     ## creating transient windows such as popup menus.
     proxy*: Wl_proxy
-
   `Xdg_wm_base / Error`* {.size: 4.} = enum
     role = 0, defunct_surfaces = 1, not_the_topmost_popup = 2,
     invalid_popup_parent = 3, invalid_surface_state = 4, invalid_positioner = 5,
@@ -312,7 +72,6 @@ type
   `Xdg_wm_base / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     ping*: proc (serial: uint32)
-
   Xdg_positioner* = object
     ## The xdg_positioner provides a collection of rules for the placement of a
     ## child surface relative to a parent surface. Rules can be defined to ensure
@@ -334,7 +93,6 @@ type
     ## set_anchor_rect. Passing an incomplete xdg_positioner object when
     ## positioning a surface raises an invalid_positioner error.
     proxy*: Wl_proxy
-
   `Xdg_positioner / Error`* {.size: 4.} = enum
     invalid_input = 0
   `Xdg_positioner / Anchor`* {.size: 4.} = enum
@@ -358,7 +116,6 @@ type
     resize_y = 32
   `Xdg_positioner / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Xdg_surface* = object
     ## An interface that may be implemented by a wl_surface, for
     ## implementations that provide a desktop-style user interface.
@@ -408,14 +165,12 @@ type
     ## has not been destroyed, i.e. the client must perform the initial commit
     ## again before attaching a buffer.
     proxy*: Wl_proxy
-
   `Xdg_surface / Error`* {.size: 4.} = enum
     not_constructed = 1, already_constructed = 2, unconfigured_buffer = 3,
     invalid_serial = 4, invalid_size = 5, defunct_role_object = 6
   `Xdg_surface / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     configure*: proc (serial: uint32)
-
   Xdg_toplevel* = object
     ## This interface defines an xdg_surface role which allows a surface to,
     ## among other things, set window-like properties such as maximize,
@@ -435,7 +190,6 @@ type
     ## 
     ## Attaching a null buffer to a toplevel unmaps the surface.
     proxy*: Wl_proxy
-
   `Xdg_toplevel / Error`* {.size: 4.} = enum
     invalid_resize_edge = 0, invalid_parent = 1, invalid_size = 2
   `Xdg_toplevel / Resize_edge`* {.size: 4.} = enum ## These values are used to indicate which edge of a surface
@@ -459,7 +213,6 @@ type
     close*: proc ()
     configure_bounds*: proc (width: int32; height: int32)
     wm_capabilities*: proc (capabilities: Wl_array)
-
   Xdg_popup* = object
     ## A popup surface is a short-lived, temporary surface. It can be used to
     ## implement for example menus, popovers, tooltips and other similar user
@@ -486,7 +239,6 @@ type
     ## The client must call wl_surface.commit on the corresponding wl_surface
     ## for the xdg_popup state to take effect.
     proxy*: Wl_proxy
-
   `Xdg_popup / Error`* {.size: 4.} = enum
     invalid_grab = 0
   `Xdg_popup / Callbacks`* = object
@@ -494,7 +246,36 @@ type
     configure*: proc (x: int32; y: int32; width: int32; height: int32)
     popup_done*: proc ()
     repositioned*: proc (token: uint32)
-
+  Org_kde_plasma_shell* = object
+    ## This interface is used by KF5 powered Wayland shells to communicate with
+    ## the compositor and can only be bound one time.
+    proxy*: Wl_proxy
+  `Org_kde_plasma_shell / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+  Org_kde_plasma_surface* = object
+    ## An interface that may be implemented by a wl_surface, for
+    ## implementations that provide the shell user interface.
+    ## 
+    ## It provides requests to set surface roles, assign an output
+    ## or set the position in output coordinates.
+    ## 
+    ## On the server side the object is automatically destroyed when
+    ## the related wl_surface is destroyed.  On client side,
+    ## org_kde_plasma_surface.destroy() must be called before
+    ## destroying the wl_surface object.
+    proxy*: Wl_proxy
+  `Org_kde_plasma_surface / Role`* {.size: 4.} = enum
+    normal = 0, desktop = 1, panel = 2, onscreendisplay = 3, notification = 4,
+    tooltip = 5, criticalnotification = 6, appletpopup = 7
+  `Org_kde_plasma_surface / Panel_behavior`* {.size: 4.} = enum ## Behavior for panel surface
+    always_visible = 1, auto_hide = 2, windows_can_cover = 3,
+    windows_go_below = 4
+  `Org_kde_plasma_surface / Error`* {.size: 4.} = enum
+    panel_not_auto_hide = 0
+  `Org_kde_plasma_surface / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    auto_hidden_panel_hidden*: proc ()
+    auto_hidden_panel_shown*: proc ()
   `Wl_display / Error`* {.size: 4.} = enum ## These errors are global and can be emitted in response to any
                                             ## server request.
     invalid_object = 0, invalid_method = 1, no_memory = 2, implementation = 3
@@ -520,12 +301,10 @@ type
     ## emit events to the client and lets the client invoke requests on
     ## the object.
     proxy*: Wl_proxy
-
   `Wl_registry / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     global*: proc (name: uint32; `interface`: cstring; version: uint32)
     global_remove*: proc (name: uint32)
-
   Wl_callback* = object
     ## Clients can handle the 'done' event to get notified when
     ## the related request is done.
@@ -533,20 +312,16 @@ type
     ## Note, because wl_callback objects are created from multiple independent
     ## factory interfaces, the wl_callback interface is frozen at version 1.
     proxy*: Wl_proxy
-
   `Wl_callback / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     done*: proc (callback_data: uint32)
-
   Wl_compositor* = object
     ## A compositor.  This object is a singleton global.  The
     ## compositor is in charge of combining the contents of multiple
     ## surfaces into one displayable output.
     proxy*: Wl_proxy
-
   `Wl_compositor / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Wl_shm_pool* = object
     ## The wl_shm_pool object encapsulates a piece of memory shared
     ## between the compositor and client.  Through the wl_shm_pool
@@ -556,10 +331,8 @@ type
     ## setup/teardown overhead and is useful when interactively resizing
     ## a surface or for many small buffers.
     proxy*: Wl_proxy
-
   `Wl_shm_pool / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Wl_shm* = object
     ## A singleton global object that provides support for shared
     ## memory.
@@ -571,7 +344,6 @@ type
     ## are emitted to inform clients about the valid pixel formats
     ## that can be used for buffers.
     proxy*: Wl_proxy
-
   `Wl_shm / Error`* {.size: 4.} = enum ## These errors can be emitted in response to wl_shm requests.
     invalid_format = 0, invalid_stride = 1, invalid_fd = 2
   `Wl_shm / Format`* {.size: 4.} = enum ## This describes the memory layout of an individual pixel.
@@ -629,7 +401,6 @@ type
   `Wl_shm / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     format*: proc (format: `Wl_shm / Format`)
-
   Wl_buffer* = object
     ## A buffer provides the content for a wl_surface. Buffers are
     ## created through factory interfaces such as wl_shm, wp_linux_buffer_params
@@ -645,11 +416,9 @@ type
     ## Note, because wl_buffer objects are created from multiple independent
     ## factory interfaces, the wl_buffer interface is frozen at version 1.
     proxy*: Wl_proxy
-
   `Wl_buffer / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     release*: proc ()
-
   Wl_data_offer* = object
     ## A wl_data_offer represents a piece of data offered for transfer
     ## by another client (the source client).  It is used by the
@@ -658,7 +427,6 @@ type
     ## converted to and provides the mechanism for transferring the
     ## data directly from the source client.
     proxy*: Wl_proxy
-
   `Wl_data_offer / Error`* {.size: 4.} = enum
     invalid_finish = 0, invalid_action_mask = 1, invalid_action = 2,
     invalid_offer = 3
@@ -667,14 +435,12 @@ type
     offer*: proc (mime_type: cstring)
     source_actions*: proc (source_actions: `Wl_data_device_manager / Dnd_action`)
     action*: proc (dnd_action: `Wl_data_device_manager / Dnd_action`)
-
   Wl_data_source* = object
     ## The wl_data_source object is the source side of a wl_data_offer.
     ## It is created by the source client in a data transfer and
     ## provides a way to describe the offered data and a way to respond
     ## to requests to transfer the data.
     proxy*: Wl_proxy
-
   `Wl_data_source / Error`* {.size: 4.} = enum
     invalid_action_mask = 0, invalid_source = 1
   `Wl_data_source / Callbacks`* = object
@@ -685,7 +451,6 @@ type
     dnd_drop_performed*: proc ()
     dnd_finished*: proc ()
     action*: proc (dnd_action: `Wl_data_device_manager / Dnd_action`)
-
   Wl_data_device* = object
     ## There is one wl_data_device per seat which can be obtained
     ## from the global wl_data_device_manager singleton.
@@ -693,7 +458,6 @@ type
     ## A wl_data_device provides access to inter-client data transfer
     ## mechanisms such as copy-and-paste and drag-and-drop.
     proxy*: Wl_proxy
-
   `Wl_data_device / Error`* {.size: 4.} = enum
     role = 0, used_source = 1
   `Wl_data_device / Callbacks`* = object
@@ -705,7 +469,6 @@ type
     motion*: proc (time: uint32; x: float32; y: float32)
     drop*: proc ()
     selection*: proc (id: Wl_data_offer)
-
   Wl_data_device_manager* = object
     ## The wl_data_device_manager is a singleton global object that
     ## provides access to inter-client data transfer mechanisms such as
@@ -718,7 +481,6 @@ type
     ## functioning properly. See wl_data_source.set_actions,
     ## wl_data_offer.accept and wl_data_offer.finish for details.
     proxy*: Wl_proxy
-
   `Wl_data_device_manager / Dnd_action`* {.size: 4.} = enum ## This is a bitmask of the available/preferred actions in a
                                                              ## drag-and-drop operation.
                                                              ## 
@@ -745,7 +507,6 @@ type
     none = 0, copy = 1, move = 2, ask = 4
   `Wl_data_device_manager / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Wl_shell* = object
     ## This interface is implemented by servers that provide
     ## desktop-style user interfaces.
@@ -757,12 +518,10 @@ type
     ## For desktop-style user interfaces, use xdg_shell. Compositors and clients
     ## should not implement this interface.
     proxy*: Wl_proxy
-
   `Wl_shell / Error`* {.size: 4.} = enum
     role = 0
   `Wl_shell / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Wl_shell_surface* = object
     ## An interface that may be implemented by a wl_surface, for
     ## implementations that provide a desktop-style user interface.
@@ -776,7 +535,6 @@ type
     ## wl_shell_surface_destroy() must be called before destroying
     ## the wl_surface object.
     proxy*: Wl_proxy
-
   `Wl_shell_surface / Resize`* {.size: 4.} = enum ## These values are used to indicate which edge of a surface
                                                    ## is being dragged in a resize operation. The server may
                                                    ## use this information to adapt its behavior, e.g. choose
@@ -796,7 +554,6 @@ type
     configure*: proc (edges: `Wl_shell_surface / Resize`; width: int32;
                       height: int32)
     popup_done*: proc ()
-
   Wl_surface* = object
     ## A surface is a rectangular area that may be displayed on zero
     ## or more outputs, and shown any number of times at the compositor's
@@ -841,7 +598,6 @@ type
     ## a cursor (cursor is a different role than sub-surface, and role
     ## switching is not allowed).
     proxy*: Wl_proxy
-
   `Wl_surface / Error`* {.size: 4.} = enum ## These errors can be emitted in response to wl_surface requests.
     invalid_scale = 0, invalid_transform = 1, invalid_size = 2,
     invalid_offset = 3, defunct_role_object = 4
@@ -851,14 +607,12 @@ type
     leave*: proc (output: Wl_output)
     preferred_buffer_scale*: proc (factor: int32)
     preferred_buffer_transform*: proc (transform: `Wl_output / Transform`)
-
   Wl_seat* = object
     ## A seat is a group of keyboards, pointer and touch devices. This
     ## object is published as a global during start up, or when such a
     ## device is hot plugged.  A seat typically has a pointer and
     ## maintains a keyboard focus and a pointer focus.
     proxy*: Wl_proxy
-
   `Wl_seat / Capability`* {.size: 4.} = enum ## This is a bitmask of capabilities this seat has; if a member is
                                               ## set, then it is present on the seat.
     pointer = 1, keyboard = 2, touch = 4
@@ -868,7 +622,6 @@ type
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     capabilities*: proc (capabilities: `Wl_seat / Capability`)
     name*: proc (name: cstring)
-
   Wl_pointer* = object
     ## The wl_pointer interface represents one or more input devices,
     ## such as mice, which control the pointer location and pointer_focus
@@ -879,7 +632,6 @@ type
     ## and button and axis events for button presses, button releases
     ## and scrolling.
     proxy*: Wl_proxy
-
   `Wl_pointer / Error`* {.size: 4.} = enum
     role = 0
   `Wl_pointer / Button_state`* {.size: 4.} = enum ## Describes the physical state of a button that produced the button
@@ -922,12 +674,10 @@ type
     axis_discrete*: proc (axis: `Wl_pointer / Axis`; discrete: int32)
     axis_value120*: proc (axis: `Wl_pointer / Axis`; value120: int32)
     axis_relative_direction*: proc (axis: `Wl_pointer / Axis`; direction: `Wl_pointer / Axis_relative_direction`)
-
   Wl_keyboard* = object
     ## The wl_keyboard interface represents one or more keyboards
     ## associated with a seat.
     proxy*: Wl_proxy
-
   `Wl_keyboard / Keymap_format`* {.size: 4.} = enum ## This specifies the format of the keymap provided to the
                                                      ## client with the wl_keyboard.keymap event.
     no_keymap = 0, xkb_v1 = 1
@@ -944,7 +694,6 @@ type
     modifiers*: proc (serial: uint32; mods_depressed: uint32;
                       mods_latched: uint32; mods_locked: uint32; group: uint32)
     repeat_info*: proc (rate: int32; delay: int32)
-
   Wl_touch* = object
     ## The wl_touch interface represents a touchscreen
     ## associated with a seat.
@@ -955,7 +704,6 @@ type
     ## and ending with an up event. Events relating to the same
     ## contact point can be identified by the ID of the sequence.
     proxy*: Wl_proxy
-
   `Wl_touch / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     down*: proc (serial: uint32; time: uint32; surface: Wl_surface; id: int32;
@@ -966,7 +714,6 @@ type
     cancel*: proc ()
     shape*: proc (id: int32; major: float32; minor: float32)
     orientation*: proc (id: int32; orientation: float32)
-
   Wl_output* = object
     ## An output describes part of the compositor geometry.  The
     ## compositor works in the 'compositor coordinate system' and an
@@ -975,7 +722,6 @@ type
     ## displays part of the compositor space.  This object is published
     ## as global during start up, or when a monitor is hotplugged.
     proxy*: Wl_proxy
-
   `Wl_output / Subpixel`* {.size: 4.} = enum ## This enumeration describes how the physical
                                               ## pixels on an output are laid out.
     unknown = 0, none = 1, horizontal_rgb = 2, horizontal_bgr = 3,
@@ -1008,17 +754,14 @@ type
     scale*: proc (factor: int32)
     name*: proc (name: cstring)
     description*: proc (description: cstring)
-
   Wl_region* = object
     ## A region object describes an area.
     ## 
     ## Region objects are used to describe the opaque and input
     ## regions of a surface.
     proxy*: Wl_proxy
-
   `Wl_region / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Wl_subcompositor* = object
     ## The global interface exposing sub-surface compositing capabilities.
     ## A wl_surface, that has sub-surfaces associated, is called the
@@ -1040,12 +783,10 @@ type
     ## objects. This should allow the compositor to pass YUV video buffer
     ## processing to dedicated overlay hardware when possible.
     proxy*: Wl_proxy
-
   `Wl_subcompositor / Error`* {.size: 4.} = enum
     bad_surface = 0, bad_parent = 1
   `Wl_subcompositor / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Wl_subsurface* = object
     ## An additional interface to a wl_surface object, which has been
     ## made a sub-surface. A sub-surface has one parent surface. A
@@ -1095,12 +836,247 @@ type
     ## If the parent wl_surface object is destroyed, the sub-surface is
     ## unmapped.
     proxy*: Wl_proxy
-
   `Wl_subsurface / Error`* {.size: 4.} = enum
     bad_surface = 0
   `Wl_subsurface / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
+  Wp_cursor_shape_manager_v1* = object
+    ## This global offers an alternative, optional way to set cursor images. This
+    ## new way uses enumerated cursors instead of a wl_surface like
+    ## wl_pointer.set_cursor does.
+    ## 
+    ## Warning! The protocol described in this file is currently in the testing
+    ## phase. Backward compatible changes may be added together with the
+    ## corresponding interface version bump. Backward incompatible changes can
+    ## only be done by creating a new major version of the extension.
+    proxy*: Wl_proxy
+  `Wp_cursor_shape_manager_v1 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+  Wp_cursor_shape_device_v1* = object
+    ## This interface advertises the list of supported cursor shapes for a
+    ## device, and allows clients to set the cursor shape.
+    proxy*: Wl_proxy
+  `Wp_cursor_shape_device_v1 / Shape`* {.size: 4.} = enum ## This enum describes cursor shapes.
+                                                           ## 
+                                                           ## The names are taken from the CSS W3C specification:
+                                                           ## https://w3c.github.io/csswg-drafts/css-ui/#cursor
+    default = 1, context_menu = 2, help = 3, pointer = 4, progress = 5,
+    wait = 6, cell = 7, crosshair = 8, text = 9, vertical_text = 10, alias = 11,
+    copy = 12, move = 13, no_drop = 14, not_allowed = 15, grab = 16,
+    grabbing = 17, e_resize = 18, n_resize = 19, ne_resize = 20, nw_resize = 21,
+    s_resize = 22, se_resize = 23, sw_resize = 24, w_resize = 25,
+    ew_resize = 26, ns_resize = 27, nesw_resize = 28, nwse_resize = 29,
+    col_resize = 30, row_resize = 31, all_scroll = 32, zoom_in = 33,
+    zoom_out = 34
+  `Wp_cursor_shape_device_v1 / Error`* {.size: 4.} = enum
+    invalid_shape = 1
+  `Wp_cursor_shape_device_v1 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+  Zwp_tablet_manager_v2* = object
+    ## An object that provides access to the graphics tablets available on this
+    ## system. All tablets are associated with a seat, to get access to the
+    ## actual tablets, use wp_tablet_manager.get_tablet_seat.
+    proxy*: Wl_proxy
+  `Zwp_tablet_manager_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+  Zwp_tablet_seat_v2* = object
+    ## An object that provides access to the graphics tablets available on this
+    ## seat. After binding to this interface, the compositor sends a set of
+    ## wp_tablet_seat.tablet_added and wp_tablet_seat.tool_added events.
+    proxy*: Wl_proxy
+  `Zwp_tablet_seat_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    tablet_added*: proc (id: Zwp_tablet_v2)
+    tool_added*: proc (id: Zwp_tablet_tool_v2)
+    pad_added*: proc (id: Zwp_tablet_pad_v2)
+  Zwp_tablet_tool_v2* = object
+    ## An object that represents a physical tool that has been, or is
+    ## currently in use with a tablet in this seat. Each wp_tablet_tool
+    ## object stays valid until the client destroys it; the compositor
+    ## reuses the wp_tablet_tool object to indicate that the object's
+    ## respective physical tool has come into proximity of a tablet again.
+    ## 
+    ## A wp_tablet_tool object's relation to a physical tool depends on the
+    ## tablet's ability to report serial numbers. If the tablet supports
+    ## this capability, then the object represents a specific physical tool
+    ## and can be identified even when used on multiple tablets.
+    ## 
+    ## A tablet tool has a number of static characteristics, e.g. tool type,
+    ## hardware_serial and capabilities. These capabilities are sent in an
+    ## event sequence after the wp_tablet_seat.tool_added event before any
+    ## actual events from this tool. This initial event sequence is
+    ## terminated by a wp_tablet_tool.done event.
+    ## 
+    ## Tablet tool events are grouped by wp_tablet_tool.frame events.
+    ## Any events received before a wp_tablet_tool.frame event should be
+    ## considered part of the same hardware state change.
+    proxy*: Wl_proxy
+  `Zwp_tablet_tool_v2 / Type`* {.size: 4.} = enum ## Describes the physical type of a tool. The physical type of a tool
+                                                   ## generally defines its base usage.
+                                                   ## 
+                                                   ## The mouse tool represents a mouse-shaped tool that is not a relative
+                                                   ## device but bound to the tablet's surface, providing absolute
+                                                   ## coordinates.
+                                                   ## 
+                                                   ## The lens tool is a mouse-shaped tool with an attached lens to
+                                                   ## provide precision focus.
+    pen = 320, eraser = 321, brush = 322, pencil = 323, airbrush = 324,
+    finger = 325, mouse = 326, lens = 327
+  `Zwp_tablet_tool_v2 / Capability`* {.size: 4.} = enum ## Describes extra capabilities on a tablet.
+                                                         ## 
+                                                         ## Any tool must provide x and y values, extra axes are
+                                                         ## device-specific.
+    tilt = 1, pressure = 2, distance = 3, rotation = 4, slider = 5, wheel = 6
+  `Zwp_tablet_tool_v2 / Button_state`* {.size: 4.} = enum ## Describes the physical state of a button that produced the button event.
+    released = 0, pressed = 1
+  `Zwp_tablet_tool_v2 / Error`* {.size: 4.} = enum
+    role = 0
+  `Zwp_tablet_tool_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    `type`*: proc (tool_type: `Zwp_tablet_tool_v2 / Type`)
+    hardware_serial*: proc (hardware_serial_hi: uint32;
+                            hardware_serial_lo: uint32)
+    hardware_id_wacom*: proc (hardware_id_hi: uint32; hardware_id_lo: uint32)
+    capability*: proc (capability: `Zwp_tablet_tool_v2 / Capability`)
+    done*: proc ()
+    removed*: proc ()
+    proximity_in*: proc (serial: uint32; tablet: Zwp_tablet_v2;
+                         surface: Wl_surface)
+    proximity_out*: proc ()
+    down*: proc (serial: uint32)
+    up*: proc ()
+    motion*: proc (x: float32; y: float32)
+    pressure*: proc (pressure: uint32)
+    distance*: proc (distance: uint32)
+    tilt*: proc (tilt_x: float32; tilt_y: float32)
+    rotation*: proc (degrees: float32)
+    slider*: proc (position: int32)
+    wheel*: proc (degrees: float32; clicks: int32)
+    button*: proc (serial: uint32; button: uint32;
+                   state: `Zwp_tablet_tool_v2 / Button_state`)
+    frame*: proc (time: uint32)
+  Zwp_tablet_v2* = object
+    ## The wp_tablet interface represents one graphics tablet device. The
+    ## tablet interface itself does not generate events; all events are
+    ## generated by wp_tablet_tool objects when in proximity above a tablet.
+    ## 
+    ## A tablet has a number of static characteristics, e.g. device name and
+    ## pid/vid. These capabilities are sent in an event sequence after the
+    ## wp_tablet_seat.tablet_added event. This initial event sequence is
+    ## terminated by a wp_tablet.done event.
+    proxy*: Wl_proxy
+  `Zwp_tablet_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    name*: proc (name: cstring)
+    id*: proc (vid: uint32; pid: uint32)
+    path*: proc (path: cstring)
+    done*: proc ()
+    removed*: proc ()
+  Zwp_tablet_pad_ring_v2* = object
+    ## A circular interaction area, such as the touch ring on the Wacom Intuos
+    ## Pro series tablets.
+    ## 
+    ## Events on a ring are logically grouped by the wl_tablet_pad_ring.frame
+    ## event.
+    proxy*: Wl_proxy
+  `Zwp_tablet_pad_ring_v2 / Source`* {.size: 4.} = enum ## Describes the source types for ring events. This indicates to the
+                                                         ## client how a ring event was physically generated; a client may
+                                                         ## adjust the user interface accordingly. For example, events
+                                                         ## from a "finger" source may trigger kinetic scrolling.
+    finger = 1
+  `Zwp_tablet_pad_ring_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    source*: proc (source: `Zwp_tablet_pad_ring_v2 / Source`)
+    angle*: proc (degrees: float32)
+    stop*: proc ()
+    frame*: proc (time: uint32)
+  Zwp_tablet_pad_strip_v2* = object
+    ## A linear interaction area, such as the strips found in Wacom Cintiq
+    ## models.
+    ## 
+    ## Events on a strip are logically grouped by the wl_tablet_pad_strip.frame
+    ## event.
+    proxy*: Wl_proxy
+  `Zwp_tablet_pad_strip_v2 / Source`* {.size: 4.} = enum ## Describes the source types for strip events. This indicates to the
+                                                          ## client how a strip event was physically generated; a client may
+                                                          ## adjust the user interface accordingly. For example, events
+                                                          ## from a "finger" source may trigger kinetic scrolling.
+    finger = 1
+  `Zwp_tablet_pad_strip_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    source*: proc (source: `Zwp_tablet_pad_strip_v2 / Source`)
+    position*: proc (position: uint32)
+    stop*: proc ()
+    frame*: proc (time: uint32)
+  Zwp_tablet_pad_group_v2* = object
+    ## A pad group describes a distinct (sub)set of buttons, rings and strips
+    ## present in the tablet. The criteria of this grouping is usually positional,
+    ## eg. if a tablet has buttons on the left and right side, 2 groups will be
+    ## presented. The physical arrangement of groups is undisclosed and may
+    ## change on the fly.
+    ## 
+    ## Pad groups will announce their features during pad initialization. Between
+    ## the corresponding wp_tablet_pad.group event and wp_tablet_pad_group.done, the
+    ## pad group will announce the buttons, rings and strips contained in it,
+    ## plus the number of supported modes.
+    ## 
+    ## Modes are a mechanism to allow multiple groups of actions for every element
+    ## in the pad group. The number of groups and available modes in each is
+    ## persistent across device plugs. The current mode is user-switchable, it
+    ## will be announced through the wp_tablet_pad_group.mode_switch event both
+    ## whenever it is switched, and after wp_tablet_pad.enter.
+    ## 
+    ## The current mode logically applies to all elements in the pad group,
+    ## although it is at clients' discretion whether to actually perform different
+    ## actions, and/or issue the respective .set_feedback requests to notify the
+    ## compositor. See the wp_tablet_pad_group.mode_switch event for more details.
+    proxy*: Wl_proxy
+  `Zwp_tablet_pad_group_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    buttons*: proc (buttons: Wl_array)
+    ring*: proc (ring: Zwp_tablet_pad_ring_v2)
+    strip*: proc (strip: Zwp_tablet_pad_strip_v2)
+    modes*: proc (modes: uint32)
+    done*: proc ()
+    mode_switch*: proc (time: uint32; serial: uint32; mode: uint32)
+  Zwp_tablet_pad_v2* = object
+    ## A pad device is a set of buttons, rings and strips
+    ## usually physically present on the tablet device itself. Some
+    ## exceptions exist where the pad device is physically detached, e.g. the
+    ## Wacom ExpressKey Remote.
+    ## 
+    ## Pad devices have no axes that control the cursor and are generally
+    ## auxiliary devices to the tool devices used on the tablet surface.
+    ## 
+    ## A pad device has a number of static characteristics, e.g. the number
+    ## of rings. These capabilities are sent in an event sequence after the
+    ## wp_tablet_seat.pad_added event before any actual events from this pad.
+    ## This initial event sequence is terminated by a wp_tablet_pad.done
+    ## event.
+    ## 
+    ## All pad features (buttons, rings and strips) are logically divided into
+    ## groups and all pads have at least one group. The available groups are
+    ## notified through the wp_tablet_pad.group event; the compositor will
+    ## emit one event per group before emitting wp_tablet_pad.done.
+    ## 
+    ## Groups may have multiple modes. Modes allow clients to map multiple
+    ## actions to a single pad feature. Only one mode can be active per group,
+    ## although different groups may have different active modes.
+    proxy*: Wl_proxy
+  `Zwp_tablet_pad_v2 / Button_state`* {.size: 4.} = enum ## Describes the physical state of a button that caused the button
+                                                          ## event.
+    released = 0, pressed = 1
+  `Zwp_tablet_pad_v2 / Callbacks`* = object
+    destroy*: proc (cb: pointer) {.cdecl, raises: [].}
+    group*: proc (pad_group: Zwp_tablet_pad_group_v2)
+    path*: proc (path: cstring)
+    buttons*: proc (buttons: uint32)
+    done*: proc ()
+    button*: proc (time: uint32; button: uint32;
+                   state: `Zwp_tablet_pad_v2 / Button_state`)
+    enter*: proc (serial: uint32; tablet: Zwp_tablet_v2; surface: Wl_surface)
+    leave*: proc (serial: uint32; surface: Wl_surface)
+    removed*: proc ()
   Zxdg_decoration_manager_v1* = object
     ## This interface allows a compositor to announce support for server-side
     ## decorations.
@@ -1125,10 +1101,8 @@ type
     ## version number in the protocol and interface names are removed and the
     ## interface version number is reset.
     proxy*: Wl_proxy
-
   `Zxdg_decoration_manager_v1 / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
-
   Zxdg_toplevel_decoration_v1* = object
     ## The decoration object allows the compositor to toggle server-side window
     ## decorations for a toplevel surface. The client can request to switch to
@@ -1137,7 +1111,6 @@ type
     ## The xdg_toplevel_decoration object must be destroyed before its
     ## xdg_toplevel.
     proxy*: Wl_proxy
-
   `Zxdg_toplevel_decoration_v1 / Error`* {.size: 4.} = enum
     unconfigured_buffer = 0, already_constructed = 1, orphaned = 2
   `Zxdg_toplevel_decoration_v1 / Mode`* {.size: 4.} = enum ## These values describe window decoration modes.
@@ -1145,54 +1118,13 @@ type
   `Zxdg_toplevel_decoration_v1 / Callbacks`* = object
     destroy*: proc (cb: pointer) {.cdecl, raises: [].}
     configure*: proc (mode: `Zxdg_toplevel_decoration_v1 / Mode`)
+var `Zwlr_layer_shell_v1 / iface`: WlInterface
+proc iface*(t: typedesc[Zwlr_layer_shell_v1]): ptr WlInterface =
+  `Zwlr_layer_shell_v1 / iface`.addr
 
-var `Zwp_tablet_manager_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_manager_v2]): ptr WlInterface =
-  `Zwp_tablet_manager_v2 / iface`.addr
-
-var `Zwp_tablet_seat_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_seat_v2]): ptr WlInterface =
-  `Zwp_tablet_seat_v2 / iface`.addr
-
-var `Zwp_tablet_tool_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_tool_v2]): ptr WlInterface =
-  `Zwp_tablet_tool_v2 / iface`.addr
-
-var `Zwp_tablet_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_v2]): ptr WlInterface =
-  `Zwp_tablet_v2 / iface`.addr
-
-var `Zwp_tablet_pad_ring_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_pad_ring_v2]): ptr WlInterface =
-  `Zwp_tablet_pad_ring_v2 / iface`.addr
-
-var `Zwp_tablet_pad_strip_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_pad_strip_v2]): ptr WlInterface =
-  `Zwp_tablet_pad_strip_v2 / iface`.addr
-
-var `Zwp_tablet_pad_group_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_pad_group_v2]): ptr WlInterface =
-  `Zwp_tablet_pad_group_v2 / iface`.addr
-
-var `Zwp_tablet_pad_v2 / iface`: WlInterface
-proc iface*(t: typedesc[Zwp_tablet_pad_v2]): ptr WlInterface =
-  `Zwp_tablet_pad_v2 / iface`.addr
-
-var `Org_kde_plasma_shell / iface`: WlInterface
-proc iface*(t: typedesc[Org_kde_plasma_shell]): ptr WlInterface =
-  `Org_kde_plasma_shell / iface`.addr
-
-var `Org_kde_plasma_surface / iface`: WlInterface
-proc iface*(t: typedesc[Org_kde_plasma_surface]): ptr WlInterface =
-  `Org_kde_plasma_surface / iface`.addr
-
-var `Wp_cursor_shape_manager_v1 / iface`: WlInterface
-proc iface*(t: typedesc[Wp_cursor_shape_manager_v1]): ptr WlInterface =
-  `Wp_cursor_shape_manager_v1 / iface`.addr
-
-var `Wp_cursor_shape_device_v1 / iface`: WlInterface
-proc iface*(t: typedesc[Wp_cursor_shape_device_v1]): ptr WlInterface =
-  `Wp_cursor_shape_device_v1 / iface`.addr
+var `Zwlr_layer_surface_v1 / iface`: WlInterface
+proc iface*(t: typedesc[Zwlr_layer_surface_v1]): ptr WlInterface =
+  `Zwlr_layer_surface_v1 / iface`.addr
 
 var `Xdg_wm_base / iface`: WlInterface
 proc iface*(t: typedesc[Xdg_wm_base]): ptr WlInterface =
@@ -1213,6 +1145,14 @@ proc iface*(t: typedesc[Xdg_toplevel]): ptr WlInterface =
 var `Xdg_popup / iface`: WlInterface
 proc iface*(t: typedesc[Xdg_popup]): ptr WlInterface =
   `Xdg_popup / iface`.addr
+
+var `Org_kde_plasma_shell / iface`: WlInterface
+proc iface*(t: typedesc[Org_kde_plasma_shell]): ptr WlInterface =
+  `Org_kde_plasma_shell / iface`.addr
+
+var `Org_kde_plasma_surface / iface`: WlInterface
+proc iface*(t: typedesc[Org_kde_plasma_surface]): ptr WlInterface =
+  `Org_kde_plasma_surface / iface`.addr
 
 var `Wl_registry / iface`: WlInterface
 proc iface*(t: typedesc[Wl_registry]): ptr WlInterface =
@@ -1298,6 +1238,46 @@ var `Wl_subsurface / iface`: WlInterface
 proc iface*(t: typedesc[Wl_subsurface]): ptr WlInterface =
   `Wl_subsurface / iface`.addr
 
+var `Wp_cursor_shape_manager_v1 / iface`: WlInterface
+proc iface*(t: typedesc[Wp_cursor_shape_manager_v1]): ptr WlInterface =
+  `Wp_cursor_shape_manager_v1 / iface`.addr
+
+var `Wp_cursor_shape_device_v1 / iface`: WlInterface
+proc iface*(t: typedesc[Wp_cursor_shape_device_v1]): ptr WlInterface =
+  `Wp_cursor_shape_device_v1 / iface`.addr
+
+var `Zwp_tablet_manager_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_manager_v2]): ptr WlInterface =
+  `Zwp_tablet_manager_v2 / iface`.addr
+
+var `Zwp_tablet_seat_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_seat_v2]): ptr WlInterface =
+  `Zwp_tablet_seat_v2 / iface`.addr
+
+var `Zwp_tablet_tool_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_tool_v2]): ptr WlInterface =
+  `Zwp_tablet_tool_v2 / iface`.addr
+
+var `Zwp_tablet_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_v2]): ptr WlInterface =
+  `Zwp_tablet_v2 / iface`.addr
+
+var `Zwp_tablet_pad_ring_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_pad_ring_v2]): ptr WlInterface =
+  `Zwp_tablet_pad_ring_v2 / iface`.addr
+
+var `Zwp_tablet_pad_strip_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_pad_strip_v2]): ptr WlInterface =
+  `Zwp_tablet_pad_strip_v2 / iface`.addr
+
+var `Zwp_tablet_pad_group_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_pad_group_v2]): ptr WlInterface =
+  `Zwp_tablet_pad_group_v2 / iface`.addr
+
+var `Zwp_tablet_pad_v2 / iface`: WlInterface
+proc iface*(t: typedesc[Zwp_tablet_pad_v2]): ptr WlInterface =
+  `Zwp_tablet_pad_v2 / iface`.addr
+
 var `Zxdg_decoration_manager_v1 / iface`: WlInterface
 proc iface*(t: typedesc[Zxdg_decoration_manager_v1]): ptr WlInterface =
   `Zxdg_decoration_manager_v1 / iface`.addr
@@ -1306,122 +1286,27 @@ var `Zxdg_toplevel_decoration_v1 / iface`: WlInterface
 proc iface*(t: typedesc[Zxdg_toplevel_decoration_v1]): ptr WlInterface =
   `Zxdg_toplevel_decoration_v1 / iface`.addr
 
-`Zwp_tablet_manager_v2 / iface` = newWlInterface("zwp_tablet_manager_v2", 1, [newWlMessage(
-    "zwp_tablet_manager_v2.get_tablet_seat", "1no",
-    [iface(Zwp_tablet_seat_v2), iface(Wl_seat)]),
-    newWlMessage("zwp_tablet_manager_v2.destroy", "1", [])], [])
-`Zwp_tablet_seat_v2 / iface` = newWlInterface("zwp_tablet_seat_v2", 1,
-    [newWlMessage("zwp_tablet_seat_v2.destroy", "1", [])], [newWlMessage(
-    "zwp_tablet_seat_v2.tablet_added", "1n", [iface(Zwp_tablet_v2)]), newWlMessage(
-    "zwp_tablet_seat_v2.tool_added", "1n", [iface(Zwp_tablet_tool_v2)]), newWlMessage(
-    "zwp_tablet_seat_v2.pad_added", "1n", [iface(Zwp_tablet_pad_v2)])])
-`Zwp_tablet_tool_v2 / iface` = newWlInterface("zwp_tablet_tool_v2", 1, [newWlMessage(
-    "zwp_tablet_tool_v2.set_cursor", "1u?oii", [(ptr WlInterface) nil,
-    iface(Wl_surface), (ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.destroy", "1", [])], [
-    newWlMessage("zwp_tablet_tool_v2.type", "1u", [(ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_tool_v2.hardware_serial", "1uu",
+`Zwlr_layer_shell_v1 / iface` = newWlInterface("zwlr_layer_shell_v1", 4, [newWlMessage(
+    "zwlr_layer_shell_v1.get_layer_surface", "1no?ous", [
+    iface(Zwlr_layer_surface_v1), iface(Wl_surface), iface(Wl_output),
+    (ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwlr_layer_shell_v1.destroy", "1", [])], [])
+`Zwlr_layer_surface_v1 / iface` = newWlInterface("zwlr_layer_surface_v1", 4, [newWlMessage(
+    "zwlr_layer_surface_v1.set_size", "1uu",
     [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_tool_v2.hardware_id_wacom", "1uu",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_tool_v2.capability", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.done", "1", []),
-    newWlMessage("zwp_tablet_tool_v2.removed", "1", []), newWlMessage(
-    "zwp_tablet_tool_v2.proximity_in", "1uoo",
-    [(ptr WlInterface) nil, iface(Zwp_tablet_v2), iface(Wl_surface)]),
-    newWlMessage("zwp_tablet_tool_v2.proximity_out", "1", []),
-    newWlMessage("zwp_tablet_tool_v2.down", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.up", "1", []), newWlMessage(
-    "zwp_tablet_tool_v2.motion", "1ff",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.pressure", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.distance", "1u", [(ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_tool_v2.tilt", "1ff",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.rotation", "1f", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.slider", "1i", [(ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_tool_v2.wheel", "1fi",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_tool_v2.button", "1uuu",
+    "zwlr_layer_surface_v1.set_anchor", "1u", [(ptr WlInterface) nil]), newWlMessage(
+    "zwlr_layer_surface_v1.set_exclusive_zone", "1i", [(ptr WlInterface) nil]), newWlMessage(
+    "zwlr_layer_surface_v1.set_margin", "1iiii", [(ptr WlInterface) nil,
+    (ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
+    "zwlr_layer_surface_v1.set_keyboard_interactivity", "1u",
+    [(ptr WlInterface) nil]),
+    newWlMessage("zwlr_layer_surface_v1.get_popup", "1o", [iface(Xdg_popup)]), newWlMessage(
+    "zwlr_layer_surface_v1.ack_configure", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("zwlr_layer_surface_v1.destroy", "1", []), newWlMessage(
+    "zwlr_layer_surface_v1.set_layer", "1u", [(ptr WlInterface) nil])], [newWlMessage(
+    "zwlr_layer_surface_v1.configure", "1uuu",
     [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_tool_v2.frame", "1u", [(ptr WlInterface) nil])])
-`Zwp_tablet_v2 / iface` = newWlInterface("zwp_tablet_v2", 1,
-    [newWlMessage("zwp_tablet_v2.destroy", "1", [])], [
-    newWlMessage("zwp_tablet_v2.name", "1s", [(ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_v2.id", "1uu", [(ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_v2.path", "1s", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_v2.done", "1", []),
-    newWlMessage("zwp_tablet_v2.removed", "1", [])])
-`Zwp_tablet_pad_ring_v2 / iface` = newWlInterface("zwp_tablet_pad_ring_v2", 1, [newWlMessage(
-    "zwp_tablet_pad_ring_v2.set_feedback", "1su",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_ring_v2.destroy", "1", [])], [newWlMessage(
-    "zwp_tablet_pad_ring_v2.source", "1u", [(ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_pad_ring_v2.angle", "1f", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_ring_v2.stop", "1", []),
-    newWlMessage("zwp_tablet_pad_ring_v2.frame", "1u", [(ptr WlInterface) nil])])
-`Zwp_tablet_pad_strip_v2 / iface` = newWlInterface("zwp_tablet_pad_strip_v2", 1, [newWlMessage(
-    "zwp_tablet_pad_strip_v2.set_feedback", "1su",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_strip_v2.destroy", "1", [])], [newWlMessage(
-    "zwp_tablet_pad_strip_v2.source", "1u", [(ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_pad_strip_v2.position", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_strip_v2.stop", "1", []), newWlMessage(
-    "zwp_tablet_pad_strip_v2.frame", "1u", [(ptr WlInterface) nil])])
-`Zwp_tablet_pad_group_v2 / iface` = newWlInterface("zwp_tablet_pad_group_v2", 1,
-    [newWlMessage("zwp_tablet_pad_group_v2.destroy", "1", [])], [newWlMessage(
-    "zwp_tablet_pad_group_v2.buttons", "1a", [(ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_pad_group_v2.ring", "1n", [iface(Zwp_tablet_pad_ring_v2)]), newWlMessage(
-    "zwp_tablet_pad_group_v2.strip", "1n", [iface(Zwp_tablet_pad_strip_v2)]), newWlMessage(
-    "zwp_tablet_pad_group_v2.modes", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_group_v2.done", "1", []), newWlMessage(
-    "zwp_tablet_pad_group_v2.mode_switch", "1uuu",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil])])
-`Zwp_tablet_pad_v2 / iface` = newWlInterface("zwp_tablet_pad_v2", 1, [newWlMessage(
-    "zwp_tablet_pad_v2.set_feedback", "1usu",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_v2.destroy", "1", [])], [newWlMessage(
-    "zwp_tablet_pad_v2.group", "1n", [iface(Zwp_tablet_pad_group_v2)]),
-    newWlMessage("zwp_tablet_pad_v2.path", "1s", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_v2.buttons", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("zwp_tablet_pad_v2.done", "1", []), newWlMessage(
-    "zwp_tablet_pad_v2.button", "1uuu",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
-    "zwp_tablet_pad_v2.enter", "1uoo",
-    [(ptr WlInterface) nil, iface(Zwp_tablet_v2), iface(Wl_surface)]), newWlMessage(
-    "zwp_tablet_pad_v2.leave", "1uo", [(ptr WlInterface) nil, iface(Wl_surface)]),
-    newWlMessage("zwp_tablet_pad_v2.removed", "1", [])])
-`Org_kde_plasma_shell / iface` = newWlInterface("org_kde_plasma_shell", 8, [newWlMessage(
-    "org_kde_plasma_shell.get_surface", "1no",
-    [iface(Org_kde_plasma_surface), iface(Wl_surface)])], [])
-`Org_kde_plasma_surface / iface` = newWlInterface("org_kde_plasma_surface", 8, [
-    newWlMessage("org_kde_plasma_surface.destroy", "1", []), newWlMessage(
-    "org_kde_plasma_surface.set_output", "1o", [iface(Wl_output)]), newWlMessage(
-    "org_kde_plasma_surface.set_position", "1ii",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
-    "org_kde_plasma_surface.set_role", "1u", [(ptr WlInterface) nil]), newWlMessage(
-    "org_kde_plasma_surface.set_panel_behavior", "1u", [(ptr WlInterface) nil]), newWlMessage(
-    "org_kde_plasma_surface.set_skip_taskbar", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("org_kde_plasma_surface.panel_auto_hide_hide", "1", []),
-    newWlMessage("org_kde_plasma_surface.panel_auto_hide_show", "1", []), newWlMessage(
-    "org_kde_plasma_surface.set_panel_takes_focus", "1u",
-    [(ptr WlInterface) nil]), newWlMessage(
-    "org_kde_plasma_surface.set_skip_switcher", "1u", [(ptr WlInterface) nil]),
-    newWlMessage("org_kde_plasma_surface.open_under_cursor", "1", [])], [
-    newWlMessage("org_kde_plasma_surface.auto_hidden_panel_hidden", "1", []),
-    newWlMessage("org_kde_plasma_surface.auto_hidden_panel_shown", "1", [])])
-`Wp_cursor_shape_manager_v1 / iface` = newWlInterface(
-    "wp_cursor_shape_manager_v1", 1, [newWlMessage(
-    "wp_cursor_shape_manager_v1.destroy", "1", []), newWlMessage(
-    "wp_cursor_shape_manager_v1.get_pointer", "1no",
-    [iface(Wp_cursor_shape_device_v1), iface(Wl_pointer)]), newWlMessage(
-    "wp_cursor_shape_manager_v1.get_tablet_tool_v2", "1no",
-    [iface(Wp_cursor_shape_device_v1), iface(Zwp_tablet_tool_v2)])], [])
-`Wp_cursor_shape_device_v1 / iface` = newWlInterface(
-    "wp_cursor_shape_device_v1", 1, [newWlMessage(
-    "wp_cursor_shape_device_v1.destroy", "1", []), newWlMessage(
-    "wp_cursor_shape_device_v1.set_shape", "1uu",
-    [(ptr WlInterface) nil, (ptr WlInterface) nil])], [])
+    newWlMessage("zwlr_layer_surface_v1.closed", "1", [])])
 `Xdg_wm_base / iface` = newWlInterface("xdg_wm_base", 6, [
     newWlMessage("xdg_wm_base.destroy", "1", []), newWlMessage(
     "xdg_wm_base.create_positioner", "1n", [iface(Xdg_positioner)]), newWlMessage(
@@ -1489,6 +1374,25 @@ proc iface*(t: typedesc[Zxdg_toplevel_decoration_v1]): ptr WlInterface =
                                      (ptr WlInterface) nil]),
     newWlMessage("xdg_popup.popup_done", "1", []),
     newWlMessage("xdg_popup.repositioned", "1u", [(ptr WlInterface) nil])])
+`Org_kde_plasma_shell / iface` = newWlInterface("org_kde_plasma_shell", 8, [newWlMessage(
+    "org_kde_plasma_shell.get_surface", "1no",
+    [iface(Org_kde_plasma_surface), iface(Wl_surface)])], [])
+`Org_kde_plasma_surface / iface` = newWlInterface("org_kde_plasma_surface", 8, [
+    newWlMessage("org_kde_plasma_surface.destroy", "1", []), newWlMessage(
+    "org_kde_plasma_surface.set_output", "1o", [iface(Wl_output)]), newWlMessage(
+    "org_kde_plasma_surface.set_position", "1ii",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
+    "org_kde_plasma_surface.set_role", "1u", [(ptr WlInterface) nil]), newWlMessage(
+    "org_kde_plasma_surface.set_panel_behavior", "1u", [(ptr WlInterface) nil]), newWlMessage(
+    "org_kde_plasma_surface.set_skip_taskbar", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("org_kde_plasma_surface.panel_auto_hide_hide", "1", []),
+    newWlMessage("org_kde_plasma_surface.panel_auto_hide_show", "1", []), newWlMessage(
+    "org_kde_plasma_surface.set_panel_takes_focus", "1u",
+    [(ptr WlInterface) nil]), newWlMessage(
+    "org_kde_plasma_surface.set_skip_switcher", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("org_kde_plasma_surface.open_under_cursor", "1", [])], [
+    newWlMessage("org_kde_plasma_surface.auto_hidden_panel_hidden", "1", []),
+    newWlMessage("org_kde_plasma_surface.auto_hidden_panel_shown", "1", [])])
 `Wl_registry / iface` = newWlInterface("wl_registry", 1, [newWlMessage(
     "wl_registry.bind", "1usun", [(ptr WlInterface) nil, (ptr WlInterface) nil])], [newWlMessage(
     "wl_registry.global", "1usu",
@@ -1695,6 +1599,103 @@ proc iface*(t: typedesc[Zxdg_toplevel_decoration_v1]): ptr WlInterface =
     newWlMessage("wl_subsurface.place_below", "1o", [iface(Wl_surface)]),
     newWlMessage("wl_subsurface.set_sync", "1", []),
     newWlMessage("wl_subsurface.set_desync", "1", [])], [])
+`Wp_cursor_shape_manager_v1 / iface` = newWlInterface(
+    "wp_cursor_shape_manager_v1", 1, [newWlMessage(
+    "wp_cursor_shape_manager_v1.destroy", "1", []), newWlMessage(
+    "wp_cursor_shape_manager_v1.get_pointer", "1no",
+    [iface(Wp_cursor_shape_device_v1), iface(Wl_pointer)]), newWlMessage(
+    "wp_cursor_shape_manager_v1.get_tablet_tool_v2", "1no",
+    [iface(Wp_cursor_shape_device_v1), iface(Zwp_tablet_tool_v2)])], [])
+`Wp_cursor_shape_device_v1 / iface` = newWlInterface(
+    "wp_cursor_shape_device_v1", 1, [newWlMessage(
+    "wp_cursor_shape_device_v1.destroy", "1", []), newWlMessage(
+    "wp_cursor_shape_device_v1.set_shape", "1uu",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil])], [])
+`Zwp_tablet_manager_v2 / iface` = newWlInterface("zwp_tablet_manager_v2", 1, [newWlMessage(
+    "zwp_tablet_manager_v2.get_tablet_seat", "1no",
+    [iface(Zwp_tablet_seat_v2), iface(Wl_seat)]),
+    newWlMessage("zwp_tablet_manager_v2.destroy", "1", [])], [])
+`Zwp_tablet_seat_v2 / iface` = newWlInterface("zwp_tablet_seat_v2", 1,
+    [newWlMessage("zwp_tablet_seat_v2.destroy", "1", [])], [newWlMessage(
+    "zwp_tablet_seat_v2.tablet_added", "1n", [iface(Zwp_tablet_v2)]), newWlMessage(
+    "zwp_tablet_seat_v2.tool_added", "1n", [iface(Zwp_tablet_tool_v2)]), newWlMessage(
+    "zwp_tablet_seat_v2.pad_added", "1n", [iface(Zwp_tablet_pad_v2)])])
+`Zwp_tablet_tool_v2 / iface` = newWlInterface("zwp_tablet_tool_v2", 1, [newWlMessage(
+    "zwp_tablet_tool_v2.set_cursor", "1u?oii", [(ptr WlInterface) nil,
+    iface(Wl_surface), (ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.destroy", "1", [])], [
+    newWlMessage("zwp_tablet_tool_v2.type", "1u", [(ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_tool_v2.hardware_serial", "1uu",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_tool_v2.hardware_id_wacom", "1uu",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_tool_v2.capability", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.done", "1", []),
+    newWlMessage("zwp_tablet_tool_v2.removed", "1", []), newWlMessage(
+    "zwp_tablet_tool_v2.proximity_in", "1uoo",
+    [(ptr WlInterface) nil, iface(Zwp_tablet_v2), iface(Wl_surface)]),
+    newWlMessage("zwp_tablet_tool_v2.proximity_out", "1", []),
+    newWlMessage("zwp_tablet_tool_v2.down", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.up", "1", []), newWlMessage(
+    "zwp_tablet_tool_v2.motion", "1ff",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.pressure", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.distance", "1u", [(ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_tool_v2.tilt", "1ff",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.rotation", "1f", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.slider", "1i", [(ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_tool_v2.wheel", "1fi",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_tool_v2.button", "1uuu",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_tool_v2.frame", "1u", [(ptr WlInterface) nil])])
+`Zwp_tablet_v2 / iface` = newWlInterface("zwp_tablet_v2", 1,
+    [newWlMessage("zwp_tablet_v2.destroy", "1", [])], [
+    newWlMessage("zwp_tablet_v2.name", "1s", [(ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_v2.id", "1uu", [(ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_v2.path", "1s", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_v2.done", "1", []),
+    newWlMessage("zwp_tablet_v2.removed", "1", [])])
+`Zwp_tablet_pad_ring_v2 / iface` = newWlInterface("zwp_tablet_pad_ring_v2", 1, [newWlMessage(
+    "zwp_tablet_pad_ring_v2.set_feedback", "1su",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_ring_v2.destroy", "1", [])], [newWlMessage(
+    "zwp_tablet_pad_ring_v2.source", "1u", [(ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_pad_ring_v2.angle", "1f", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_ring_v2.stop", "1", []),
+    newWlMessage("zwp_tablet_pad_ring_v2.frame", "1u", [(ptr WlInterface) nil])])
+`Zwp_tablet_pad_strip_v2 / iface` = newWlInterface("zwp_tablet_pad_strip_v2", 1, [newWlMessage(
+    "zwp_tablet_pad_strip_v2.set_feedback", "1su",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_strip_v2.destroy", "1", [])], [newWlMessage(
+    "zwp_tablet_pad_strip_v2.source", "1u", [(ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_pad_strip_v2.position", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_strip_v2.stop", "1", []), newWlMessage(
+    "zwp_tablet_pad_strip_v2.frame", "1u", [(ptr WlInterface) nil])])
+`Zwp_tablet_pad_group_v2 / iface` = newWlInterface("zwp_tablet_pad_group_v2", 1,
+    [newWlMessage("zwp_tablet_pad_group_v2.destroy", "1", [])], [newWlMessage(
+    "zwp_tablet_pad_group_v2.buttons", "1a", [(ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_pad_group_v2.ring", "1n", [iface(Zwp_tablet_pad_ring_v2)]), newWlMessage(
+    "zwp_tablet_pad_group_v2.strip", "1n", [iface(Zwp_tablet_pad_strip_v2)]), newWlMessage(
+    "zwp_tablet_pad_group_v2.modes", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_group_v2.done", "1", []), newWlMessage(
+    "zwp_tablet_pad_group_v2.mode_switch", "1uuu",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil])])
+`Zwp_tablet_pad_v2 / iface` = newWlInterface("zwp_tablet_pad_v2", 1, [newWlMessage(
+    "zwp_tablet_pad_v2.set_feedback", "1usu",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_v2.destroy", "1", [])], [newWlMessage(
+    "zwp_tablet_pad_v2.group", "1n", [iface(Zwp_tablet_pad_group_v2)]),
+    newWlMessage("zwp_tablet_pad_v2.path", "1s", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_v2.buttons", "1u", [(ptr WlInterface) nil]),
+    newWlMessage("zwp_tablet_pad_v2.done", "1", []), newWlMessage(
+    "zwp_tablet_pad_v2.button", "1uuu",
+    [(ptr WlInterface) nil, (ptr WlInterface) nil, (ptr WlInterface) nil]), newWlMessage(
+    "zwp_tablet_pad_v2.enter", "1uoo",
+    [(ptr WlInterface) nil, iface(Zwp_tablet_v2), iface(Wl_surface)]), newWlMessage(
+    "zwp_tablet_pad_v2.leave", "1uo", [(ptr WlInterface) nil, iface(Wl_surface)]),
+    newWlMessage("zwp_tablet_pad_v2.removed", "1", [])])
 `Zxdg_decoration_manager_v1 / iface` = newWlInterface(
     "zxdg_decoration_manager_v1", 1, [newWlMessage(
     "zxdg_decoration_manager_v1.destroy", "1", []), newWlMessage(
@@ -1706,295 +1707,26 @@ proc iface*(t: typedesc[Zxdg_toplevel_decoration_v1]): ptr WlInterface =
     "zxdg_toplevel_decoration_v1.set_mode", "1u", [(ptr WlInterface) nil]), newWlMessage(
     "zxdg_toplevel_decoration_v1.unset_mode", "1", [])], [newWlMessage(
     "zxdg_toplevel_decoration_v1.configure", "1u", [(ptr WlInterface) nil])])
-proc `Zwp_tablet_manager_v2 / dispatch`*(impl: pointer; obj: pointer;
+proc `Zwlr_layer_shell_v1 / dispatch`*(impl: pointer; obj: pointer;
+                                       opcode: uint32; msg: ptr WlMessage;
+                                       args: pointer): int32 {.cdecl.} =
+  case opcode
+  else:
+    discard
+
+proc `Zwlr_layer_surface_v1 / dispatch`*(impl: pointer; obj: pointer;
     opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
-  case opcode
-  else:
-    discard
-
-proc `Zwp_tablet_seat_v2 / dispatch`*(impl: pointer; obj: pointer;
-                                      opcode: uint32; msg: ptr WlMessage;
-                                      args: pointer): int32 {.cdecl.} =
-  let callbacks = cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](impl)
+  let callbacks = cast[ptr `Zwlr_layer_surface_v1 / Callbacks`](impl)
   case opcode
   of 0:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.tablet_added != nil:
-      callbacks.tablet_added(cast[Zwp_tablet_v2](argsArray[][0]))
-  of 1:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.tool_added != nil:
-      callbacks.tool_added(cast[Zwp_tablet_tool_v2](argsArray[][0]))
-  of 2:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.pad_added != nil:
-      callbacks.pad_added(cast[Zwp_tablet_pad_v2](argsArray[][0]))
-  else:
-    discard
-
-proc `Zwp_tablet_tool_v2 / dispatch`*(impl: pointer; obj: pointer;
-                                      opcode: uint32; msg: ptr WlMessage;
-                                      args: pointer): int32 {.cdecl.} =
-  let callbacks = cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](impl)
-  case opcode
-  of 0:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.`type` != nil:
-      callbacks.`type`(cast[`Zwp_tablet_tool_v2 / Type`](argsArray[][0]))
-  of 1:
-    let argsArray = cast[ptr array[2, Wl_argument]](args)
-    if callbacks.hardware_serial != nil:
-      callbacks.hardware_serial(cast[uint32](argsArray[][0]),
-                                cast[uint32](argsArray[][1]))
-  of 2:
-    let argsArray = cast[ptr array[2, Wl_argument]](args)
-    if callbacks.hardware_id_wacom != nil:
-      callbacks.hardware_id_wacom(cast[uint32](argsArray[][0]),
-                                  cast[uint32](argsArray[][1]))
-  of 3:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.capability != nil:
-      callbacks.capability(cast[`Zwp_tablet_tool_v2 / Capability`](argsArray[][0]))
-  of 4:
-    if callbacks.done != nil:
-      callbacks.done()
-  of 5:
-    if callbacks.removed != nil:
-      callbacks.removed()
-  of 6:
     let argsArray = cast[ptr array[3, Wl_argument]](args)
-    if callbacks.proximity_in != nil:
-      callbacks.proximity_in(cast[uint32](argsArray[][0]),
-                             cast[Zwp_tablet_v2](argsArray[][1]),
-                             cast[Wl_surface](argsArray[][2]))
-  of 7:
-    if callbacks.proximity_out != nil:
-      callbacks.proximity_out()
-  of 8:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.down != nil:
-      callbacks.down(cast[uint32](argsArray[][0]))
-  of 9:
-    if callbacks.up != nil:
-      callbacks.up()
-  of 10:
-    let argsArray = cast[ptr array[2, Wl_argument]](args)
-    if callbacks.motion != nil:
-      callbacks.motion(cast[int32](argsArray[][0]).float32 / 256,
-                       cast[int32](argsArray[][1]).float32 / 256)
-  of 11:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.pressure != nil:
-      callbacks.pressure(cast[uint32](argsArray[][0]))
-  of 12:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.distance != nil:
-      callbacks.distance(cast[uint32](argsArray[][0]))
-  of 13:
-    let argsArray = cast[ptr array[2, Wl_argument]](args)
-    if callbacks.tilt != nil:
-      callbacks.tilt(cast[int32](argsArray[][0]).float32 / 256,
-                     cast[int32](argsArray[][1]).float32 / 256)
-  of 14:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.rotation != nil:
-      callbacks.rotation(cast[int32](argsArray[][0]).float32 / 256)
-  of 15:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.slider != nil:
-      callbacks.slider(cast[int32](argsArray[][0]))
-  of 16:
-    let argsArray = cast[ptr array[2, Wl_argument]](args)
-    if callbacks.wheel != nil:
-      callbacks.wheel(cast[int32](argsArray[][0]).float32 / 256,
-                      cast[int32](argsArray[][1]))
-  of 17:
-    let argsArray = cast[ptr array[3, Wl_argument]](args)
-    if callbacks.button != nil:
-      callbacks.button(cast[uint32](argsArray[][0]),
-                       cast[uint32](argsArray[][1]),
-                       cast[`Zwp_tablet_tool_v2 / Button_state`](argsArray[][2]))
-  of 18:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.frame != nil:
-      callbacks.frame(cast[uint32](argsArray[][0]))
-  else:
-    discard
-
-proc `Zwp_tablet_v2 / dispatch`*(impl: pointer; obj: pointer; opcode: uint32;
-                                 msg: ptr WlMessage; args: pointer): int32 {.
-    cdecl.} =
-  let callbacks = cast[ptr `Zwp_tablet_v2 / Callbacks`](impl)
-  case opcode
-  of 0:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.name != nil:
-      callbacks.name(cast[cstring](argsArray[][0]))
+    if callbacks.configure != nil:
+      callbacks.configure(cast[uint32](argsArray[][0]),
+                          cast[uint32](argsArray[][1]),
+                          cast[uint32](argsArray[][2]))
   of 1:
-    let argsArray = cast[ptr array[2, Wl_argument]](args)
-    if callbacks.id != nil:
-      callbacks.id(cast[uint32](argsArray[][0]), cast[uint32](argsArray[][1]))
-  of 2:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.path != nil:
-      callbacks.path(cast[cstring](argsArray[][0]))
-  of 3:
-    if callbacks.done != nil:
-      callbacks.done()
-  of 4:
-    if callbacks.removed != nil:
-      callbacks.removed()
-  else:
-    discard
-
-proc `Zwp_tablet_pad_ring_v2 / dispatch`*(impl: pointer; obj: pointer;
-    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
-  let callbacks = cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](impl)
-  case opcode
-  of 0:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.source != nil:
-      callbacks.source(cast[`Zwp_tablet_pad_ring_v2 / Source`](argsArray[][0]))
-  of 1:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.angle != nil:
-      callbacks.angle(cast[int32](argsArray[][0]).float32 / 256)
-  of 2:
-    if callbacks.stop != nil:
-      callbacks.stop()
-  of 3:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.frame != nil:
-      callbacks.frame(cast[uint32](argsArray[][0]))
-  else:
-    discard
-
-proc `Zwp_tablet_pad_strip_v2 / dispatch`*(impl: pointer; obj: pointer;
-    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
-  let callbacks = cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](impl)
-  case opcode
-  of 0:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.source != nil:
-      callbacks.source(cast[`Zwp_tablet_pad_strip_v2 / Source`](argsArray[][0]))
-  of 1:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.position != nil:
-      callbacks.position(cast[uint32](argsArray[][0]))
-  of 2:
-    if callbacks.stop != nil:
-      callbacks.stop()
-  of 3:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.frame != nil:
-      callbacks.frame(cast[uint32](argsArray[][0]))
-  else:
-    discard
-
-proc `Zwp_tablet_pad_group_v2 / dispatch`*(impl: pointer; obj: pointer;
-    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
-  let callbacks = cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](impl)
-  case opcode
-  of 0:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.buttons != nil:
-      callbacks.buttons(cast[Wl_array](argsArray[][0]))
-  of 1:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.ring != nil:
-      callbacks.ring(cast[Zwp_tablet_pad_ring_v2](argsArray[][0]))
-  of 2:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.strip != nil:
-      callbacks.strip(cast[Zwp_tablet_pad_strip_v2](argsArray[][0]))
-  of 3:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.modes != nil:
-      callbacks.modes(cast[uint32](argsArray[][0]))
-  of 4:
-    if callbacks.done != nil:
-      callbacks.done()
-  of 5:
-    let argsArray = cast[ptr array[3, Wl_argument]](args)
-    if callbacks.mode_switch != nil:
-      callbacks.mode_switch(cast[uint32](argsArray[][0]),
-                            cast[uint32](argsArray[][1]),
-                            cast[uint32](argsArray[][2]))
-  else:
-    discard
-
-proc `Zwp_tablet_pad_v2 / dispatch`*(impl: pointer; obj: pointer;
-                                     opcode: uint32; msg: ptr WlMessage;
-                                     args: pointer): int32 {.cdecl.} =
-  let callbacks = cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](impl)
-  case opcode
-  of 0:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.group != nil:
-      callbacks.group(cast[Zwp_tablet_pad_group_v2](argsArray[][0]))
-  of 1:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.path != nil:
-      callbacks.path(cast[cstring](argsArray[][0]))
-  of 2:
-    let argsArray = cast[ptr array[1, Wl_argument]](args)
-    if callbacks.buttons != nil:
-      callbacks.buttons(cast[uint32](argsArray[][0]))
-  of 3:
-    if callbacks.done != nil:
-      callbacks.done()
-  of 4:
-    let argsArray = cast[ptr array[3, Wl_argument]](args)
-    if callbacks.button != nil:
-      callbacks.button(cast[uint32](argsArray[][0]),
-                       cast[uint32](argsArray[][1]),
-                       cast[`Zwp_tablet_pad_v2 / Button_state`](argsArray[][2]))
-  of 5:
-    let argsArray = cast[ptr array[3, Wl_argument]](args)
-    if callbacks.enter != nil:
-      callbacks.enter(cast[uint32](argsArray[][0]),
-                      cast[Zwp_tablet_v2](argsArray[][1]),
-                      cast[Wl_surface](argsArray[][2]))
-  of 6:
-    let argsArray = cast[ptr array[2, Wl_argument]](args)
-    if callbacks.leave != nil:
-      callbacks.leave(cast[uint32](argsArray[][0]),
-                      cast[Wl_surface](argsArray[][1]))
-  of 7:
-    if callbacks.removed != nil:
-      callbacks.removed()
-  else:
-    discard
-
-proc `Org_kde_plasma_shell / dispatch`*(impl: pointer; obj: pointer;
-                                        opcode: uint32; msg: ptr WlMessage;
-                                        args: pointer): int32 {.cdecl.} =
-  case opcode
-  else:
-    discard
-
-proc `Org_kde_plasma_surface / dispatch`*(impl: pointer; obj: pointer;
-    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
-  let callbacks = cast[ptr `Org_kde_plasma_surface / Callbacks`](impl)
-  case opcode
-  of 0:
-    if callbacks.auto_hidden_panel_hidden != nil:
-      callbacks.auto_hidden_panel_hidden()
-  of 1:
-    if callbacks.auto_hidden_panel_shown != nil:
-      callbacks.auto_hidden_panel_shown()
-  else:
-    discard
-
-proc `Wp_cursor_shape_manager_v1 / dispatch`*(impl: pointer; obj: pointer;
-    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
-  case opcode
-  else:
-    discard
-
-proc `Wp_cursor_shape_device_v1 / dispatch`*(impl: pointer; obj: pointer;
-    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
-  case opcode
+    if callbacks.closed != nil:
+      callbacks.closed()
   else:
     discard
 
@@ -2071,6 +1803,26 @@ proc `Xdg_popup / dispatch`*(impl: pointer; obj: pointer; opcode: uint32;
     let argsArray = cast[ptr array[1, Wl_argument]](args)
     if callbacks.repositioned != nil:
       callbacks.repositioned(cast[uint32](argsArray[][0]))
+  else:
+    discard
+
+proc `Org_kde_plasma_shell / dispatch`*(impl: pointer; obj: pointer;
+                                        opcode: uint32; msg: ptr WlMessage;
+                                        args: pointer): int32 {.cdecl.} =
+  case opcode
+  else:
+    discard
+
+proc `Org_kde_plasma_surface / dispatch`*(impl: pointer; obj: pointer;
+    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
+  let callbacks = cast[ptr `Org_kde_plasma_surface / Callbacks`](impl)
+  case opcode
+  of 0:
+    if callbacks.auto_hidden_panel_hidden != nil:
+      callbacks.auto_hidden_panel_hidden()
+  of 1:
+    if callbacks.auto_hidden_panel_shown != nil:
+      callbacks.auto_hidden_panel_shown()
   else:
     discard
 
@@ -2506,6 +2258,278 @@ proc `Wl_subsurface / dispatch`*(impl: pointer; obj: pointer; opcode: uint32;
   else:
     discard
 
+proc `Wp_cursor_shape_manager_v1 / dispatch`*(impl: pointer; obj: pointer;
+    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
+  case opcode
+  else:
+    discard
+
+proc `Wp_cursor_shape_device_v1 / dispatch`*(impl: pointer; obj: pointer;
+    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
+  case opcode
+  else:
+    discard
+
+proc `Zwp_tablet_manager_v2 / dispatch`*(impl: pointer; obj: pointer;
+    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
+  case opcode
+  else:
+    discard
+
+proc `Zwp_tablet_seat_v2 / dispatch`*(impl: pointer; obj: pointer;
+                                      opcode: uint32; msg: ptr WlMessage;
+                                      args: pointer): int32 {.cdecl.} =
+  let callbacks = cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](impl)
+  case opcode
+  of 0:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.tablet_added != nil:
+      callbacks.tablet_added(cast[Zwp_tablet_v2](argsArray[][0]))
+  of 1:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.tool_added != nil:
+      callbacks.tool_added(cast[Zwp_tablet_tool_v2](argsArray[][0]))
+  of 2:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.pad_added != nil:
+      callbacks.pad_added(cast[Zwp_tablet_pad_v2](argsArray[][0]))
+  else:
+    discard
+
+proc `Zwp_tablet_tool_v2 / dispatch`*(impl: pointer; obj: pointer;
+                                      opcode: uint32; msg: ptr WlMessage;
+                                      args: pointer): int32 {.cdecl.} =
+  let callbacks = cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](impl)
+  case opcode
+  of 0:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.`type` != nil:
+      callbacks.`type`(cast[`Zwp_tablet_tool_v2 / Type`](argsArray[][0]))
+  of 1:
+    let argsArray = cast[ptr array[2, Wl_argument]](args)
+    if callbacks.hardware_serial != nil:
+      callbacks.hardware_serial(cast[uint32](argsArray[][0]),
+                                cast[uint32](argsArray[][1]))
+  of 2:
+    let argsArray = cast[ptr array[2, Wl_argument]](args)
+    if callbacks.hardware_id_wacom != nil:
+      callbacks.hardware_id_wacom(cast[uint32](argsArray[][0]),
+                                  cast[uint32](argsArray[][1]))
+  of 3:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.capability != nil:
+      callbacks.capability(cast[`Zwp_tablet_tool_v2 / Capability`](argsArray[][0]))
+  of 4:
+    if callbacks.done != nil:
+      callbacks.done()
+  of 5:
+    if callbacks.removed != nil:
+      callbacks.removed()
+  of 6:
+    let argsArray = cast[ptr array[3, Wl_argument]](args)
+    if callbacks.proximity_in != nil:
+      callbacks.proximity_in(cast[uint32](argsArray[][0]),
+                             cast[Zwp_tablet_v2](argsArray[][1]),
+                             cast[Wl_surface](argsArray[][2]))
+  of 7:
+    if callbacks.proximity_out != nil:
+      callbacks.proximity_out()
+  of 8:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.down != nil:
+      callbacks.down(cast[uint32](argsArray[][0]))
+  of 9:
+    if callbacks.up != nil:
+      callbacks.up()
+  of 10:
+    let argsArray = cast[ptr array[2, Wl_argument]](args)
+    if callbacks.motion != nil:
+      callbacks.motion(cast[int32](argsArray[][0]).float32 / 256,
+                       cast[int32](argsArray[][1]).float32 / 256)
+  of 11:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.pressure != nil:
+      callbacks.pressure(cast[uint32](argsArray[][0]))
+  of 12:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.distance != nil:
+      callbacks.distance(cast[uint32](argsArray[][0]))
+  of 13:
+    let argsArray = cast[ptr array[2, Wl_argument]](args)
+    if callbacks.tilt != nil:
+      callbacks.tilt(cast[int32](argsArray[][0]).float32 / 256,
+                     cast[int32](argsArray[][1]).float32 / 256)
+  of 14:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.rotation != nil:
+      callbacks.rotation(cast[int32](argsArray[][0]).float32 / 256)
+  of 15:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.slider != nil:
+      callbacks.slider(cast[int32](argsArray[][0]))
+  of 16:
+    let argsArray = cast[ptr array[2, Wl_argument]](args)
+    if callbacks.wheel != nil:
+      callbacks.wheel(cast[int32](argsArray[][0]).float32 / 256,
+                      cast[int32](argsArray[][1]))
+  of 17:
+    let argsArray = cast[ptr array[3, Wl_argument]](args)
+    if callbacks.button != nil:
+      callbacks.button(cast[uint32](argsArray[][0]),
+                       cast[uint32](argsArray[][1]),
+                       cast[`Zwp_tablet_tool_v2 / Button_state`](argsArray[][2]))
+  of 18:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.frame != nil:
+      callbacks.frame(cast[uint32](argsArray[][0]))
+  else:
+    discard
+
+proc `Zwp_tablet_v2 / dispatch`*(impl: pointer; obj: pointer; opcode: uint32;
+                                 msg: ptr WlMessage; args: pointer): int32 {.
+    cdecl.} =
+  let callbacks = cast[ptr `Zwp_tablet_v2 / Callbacks`](impl)
+  case opcode
+  of 0:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.name != nil:
+      callbacks.name(cast[cstring](argsArray[][0]))
+  of 1:
+    let argsArray = cast[ptr array[2, Wl_argument]](args)
+    if callbacks.id != nil:
+      callbacks.id(cast[uint32](argsArray[][0]), cast[uint32](argsArray[][1]))
+  of 2:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.path != nil:
+      callbacks.path(cast[cstring](argsArray[][0]))
+  of 3:
+    if callbacks.done != nil:
+      callbacks.done()
+  of 4:
+    if callbacks.removed != nil:
+      callbacks.removed()
+  else:
+    discard
+
+proc `Zwp_tablet_pad_ring_v2 / dispatch`*(impl: pointer; obj: pointer;
+    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
+  let callbacks = cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](impl)
+  case opcode
+  of 0:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.source != nil:
+      callbacks.source(cast[`Zwp_tablet_pad_ring_v2 / Source`](argsArray[][0]))
+  of 1:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.angle != nil:
+      callbacks.angle(cast[int32](argsArray[][0]).float32 / 256)
+  of 2:
+    if callbacks.stop != nil:
+      callbacks.stop()
+  of 3:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.frame != nil:
+      callbacks.frame(cast[uint32](argsArray[][0]))
+  else:
+    discard
+
+proc `Zwp_tablet_pad_strip_v2 / dispatch`*(impl: pointer; obj: pointer;
+    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
+  let callbacks = cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](impl)
+  case opcode
+  of 0:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.source != nil:
+      callbacks.source(cast[`Zwp_tablet_pad_strip_v2 / Source`](argsArray[][0]))
+  of 1:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.position != nil:
+      callbacks.position(cast[uint32](argsArray[][0]))
+  of 2:
+    if callbacks.stop != nil:
+      callbacks.stop()
+  of 3:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.frame != nil:
+      callbacks.frame(cast[uint32](argsArray[][0]))
+  else:
+    discard
+
+proc `Zwp_tablet_pad_group_v2 / dispatch`*(impl: pointer; obj: pointer;
+    opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
+  let callbacks = cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](impl)
+  case opcode
+  of 0:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.buttons != nil:
+      callbacks.buttons(cast[Wl_array](argsArray[][0]))
+  of 1:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.ring != nil:
+      callbacks.ring(cast[Zwp_tablet_pad_ring_v2](argsArray[][0]))
+  of 2:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.strip != nil:
+      callbacks.strip(cast[Zwp_tablet_pad_strip_v2](argsArray[][0]))
+  of 3:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.modes != nil:
+      callbacks.modes(cast[uint32](argsArray[][0]))
+  of 4:
+    if callbacks.done != nil:
+      callbacks.done()
+  of 5:
+    let argsArray = cast[ptr array[3, Wl_argument]](args)
+    if callbacks.mode_switch != nil:
+      callbacks.mode_switch(cast[uint32](argsArray[][0]),
+                            cast[uint32](argsArray[][1]),
+                            cast[uint32](argsArray[][2]))
+  else:
+    discard
+
+proc `Zwp_tablet_pad_v2 / dispatch`*(impl: pointer; obj: pointer;
+                                     opcode: uint32; msg: ptr WlMessage;
+                                     args: pointer): int32 {.cdecl.} =
+  let callbacks = cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](impl)
+  case opcode
+  of 0:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.group != nil:
+      callbacks.group(cast[Zwp_tablet_pad_group_v2](argsArray[][0]))
+  of 1:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.path != nil:
+      callbacks.path(cast[cstring](argsArray[][0]))
+  of 2:
+    let argsArray = cast[ptr array[1, Wl_argument]](args)
+    if callbacks.buttons != nil:
+      callbacks.buttons(cast[uint32](argsArray[][0]))
+  of 3:
+    if callbacks.done != nil:
+      callbacks.done()
+  of 4:
+    let argsArray = cast[ptr array[3, Wl_argument]](args)
+    if callbacks.button != nil:
+      callbacks.button(cast[uint32](argsArray[][0]),
+                       cast[uint32](argsArray[][1]),
+                       cast[`Zwp_tablet_pad_v2 / Button_state`](argsArray[][2]))
+  of 5:
+    let argsArray = cast[ptr array[3, Wl_argument]](args)
+    if callbacks.enter != nil:
+      callbacks.enter(cast[uint32](argsArray[][0]),
+                      cast[Zwp_tablet_v2](argsArray[][1]),
+                      cast[Wl_surface](argsArray[][2]))
+  of 6:
+    let argsArray = cast[ptr array[2, Wl_argument]](args)
+    if callbacks.leave != nil:
+      callbacks.leave(cast[uint32](argsArray[][0]),
+                      cast[Wl_surface](argsArray[][1]))
+  of 7:
+    if callbacks.removed != nil:
+      callbacks.removed()
+  else:
+    discard
+
 proc `Zxdg_decoration_manager_v1 / dispatch`*(impl: pointer; obj: pointer;
     opcode: uint32; msg: ptr WlMessage; args: pointer): int32 {.cdecl.} =
   case opcode
@@ -2524,396 +2548,168 @@ proc `Zxdg_toplevel_decoration_v1 / dispatch`*(impl: pointer; obj: pointer;
   else:
     discard
 
-proc get_tablet_seat*(this: Zwp_tablet_manager_v2; seat: Wl_seat): Zwp_tablet_seat_v2 =
-  ## Get the wp_tablet_seat object for the given seat. This object
-  ## provides access to all graphics tablets in this seat.
-  result = construct(wl_proxy_marshal_flags(this.proxy.raw, 0,
-      Zwp_tablet_seat_v2.iface, 1, 0, nil, seat), Zwp_tablet_seat_v2,
-                     `Zwp_tablet_seat_v2 / dispatch`,
-                     `Zwp_tablet_seat_v2 / Callbacks`)
-
-proc destroy*(this: Zwp_tablet_manager_v2) =
-  ## Destroy the wp_tablet_manager object. Objects created from this
-  ## object are unaffected and should be destroyed separately.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
-
-proc destroy*(this: Zwp_tablet_seat_v2) =
-  ## Destroy the wp_tablet_seat object. Objects created from this
-  ## object are unaffected and should be destroyed separately.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
-
-proc set_cursor*(this: Zwp_tablet_tool_v2; serial: uint32; surface: Wl_surface;
-                 hotspot_x: int32; hotspot_y: int32) =
-  ## Sets the surface of the cursor used for this tool on the given
-  ## tablet. This request only takes effect if the tool is in proximity
-  ## of one of the requesting client's surfaces or the surface parameter
-  ## is the current pointer surface. If there was a previous surface set
-  ## with this request it is replaced. If surface is NULL, the cursor
-  ## image is hidden.
+proc get_layer_surface*(this: Zwlr_layer_shell_v1; surface: Wl_surface;
+                        output: Wl_output; layer: `Zwlr_layer_shell_v1 / Layer`;
+                        namespace: cstring): Zwlr_layer_surface_v1 =
+  ## Create a layer surface for an existing surface. This assigns the role of
+  ## layer_surface, or raises a protocol error if another role is already
+  ## assigned.
   ## 
-  ## The parameters hotspot_x and hotspot_y define the position of the
-  ## pointer surface relative to the pointer location. Its top-left corner
-  ## is always at (x, y) - (hotspot_x, hotspot_y), where (x, y) are the
-  ## coordinates of the pointer location, in surface-local coordinates.
+  ## Creating a layer surface from a wl_surface which has a buffer attached
+  ## or committed is a client error, and any attempts by a client to attach
+  ## or manipulate a buffer prior to the first layer_surface.configure call
+  ## must also be treated as errors.
   ## 
-  ## On surface.attach requests to the pointer surface, hotspot_x and
-  ## hotspot_y are decremented by the x and y parameters passed to the
-  ## request. Attach must be confirmed by wl_surface.commit as usual.
+  ## After creating a layer_surface object and setting it up, the client
+  ## must perform an initial commit without any buffer attached.
+  ## The compositor will reply with a layer_surface.configure event.
+  ## The client must acknowledge it and is then allowed to attach a buffer
+  ## to map the surface.
   ## 
-  ## The hotspot can also be updated by passing the currently set pointer
-  ## surface to this request with new values for hotspot_x and hotspot_y.
+  ## You may pass NULL for output to allow the compositor to decide which
+  ## output to use. Generally this will be the one that the user most
+  ## recently interacted with.
   ## 
-  ## The current and pending input regions of the wl_surface are cleared,
-  ## and wl_surface.set_input_region is ignored until the wl_surface is no
-  ## longer used as the cursor. When the use as a cursor ends, the current
-  ## and pending input regions become undefined, and the wl_surface is
-  ## unmapped.
-  ## 
-  ## This request gives the surface the role of a wp_tablet_tool cursor. A
-  ## surface may only ever be used as the cursor surface for one
-  ## wp_tablet_tool. If the surface already has another role or has
-  ## previously been used as cursor surface for a different tool, a
-  ## protocol error is raised.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, serial, surface,
-                                 hotspot_x, hotspot_y)
-
-proc destroy*(this: Zwp_tablet_tool_v2) =
-  ## This destroys the client's resource for this tool object.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
-
-proc destroy*(this: Zwp_tablet_v2) =
-  ## This destroys the client's resource for this tablet object.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
-
-proc set_feedback*(this: Zwp_tablet_pad_ring_v2; description: cstring;
-                   serial: uint32) =
-  ## Request that the compositor use the provided feedback string
-  ## associated with this ring. This request should be issued immediately
-  ## after a wp_tablet_pad_group.mode_switch event from the corresponding
-  ## group is received, or whenever the ring is mapped to a different
-  ## action. See wp_tablet_pad_group.mode_switch for more details.
-  ## 
-  ## Clients are encouraged to provide context-aware descriptions for
-  ## the actions associated with the ring; compositors may use this
-  ## information to offer visual feedback about the button layout
-  ## (eg. on-screen displays).
-  ## 
-  ## The provided string 'description' is a UTF-8 encoded string to be
-  ## associated with this ring, and is considered user-visible; general
-  ## internationalization rules apply.
-  ## 
-  ## The serial argument will be that of the last
-  ## wp_tablet_pad_group.mode_switch event received for the group of this
-  ## ring. Requests providing other serials than the most recent one will be
-  ## ignored.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, description,
-                                 serial)
-
-proc destroy*(this: Zwp_tablet_pad_ring_v2) =
-  ## This destroys the client's resource for this ring object.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
-
-proc set_feedback*(this: Zwp_tablet_pad_strip_v2; description: cstring;
-                   serial: uint32) =
-  ## Requests the compositor to use the provided feedback string
-  ## associated with this strip. This request should be issued immediately
-  ## after a wp_tablet_pad_group.mode_switch event from the corresponding
-  ## group is received, or whenever the strip is mapped to a different
-  ## action. See wp_tablet_pad_group.mode_switch for more details.
-  ## 
-  ## Clients are encouraged to provide context-aware descriptions for
-  ## the actions associated with the strip, and compositors may use this
-  ## information to offer visual feedback about the button layout
-  ## (eg. on-screen displays).
-  ## 
-  ## The provided string 'description' is a UTF-8 encoded string to be
-  ## associated with this ring, and is considered user-visible; general
-  ## internationalization rules apply.
-  ## 
-  ## The serial argument will be that of the last
-  ## wp_tablet_pad_group.mode_switch event received for the group of this
-  ## strip. Requests providing other serials than the most recent one will be
-  ## ignored.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, description,
-                                 serial)
-
-proc destroy*(this: Zwp_tablet_pad_strip_v2) =
-  ## This destroys the client's resource for this strip object.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
-
-proc destroy*(this: Zwp_tablet_pad_group_v2) =
-  ## Destroy the wp_tablet_pad_group object. Objects created from this object
-  ## are unaffected and should be destroyed separately.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
-
-proc set_feedback*(this: Zwp_tablet_pad_v2; button: uint32;
-                   description: cstring; serial: uint32) =
-  ## Requests the compositor to use the provided feedback string
-  ## associated with this button. This request should be issued immediately
-  ## after a wp_tablet_pad_group.mode_switch event from the corresponding
-  ## group is received, or whenever a button is mapped to a different
-  ## action. See wp_tablet_pad_group.mode_switch for more details.
-  ## 
-  ## Clients are encouraged to provide context-aware descriptions for
-  ## the actions associated with each button, and compositors may use
-  ## this information to offer visual feedback on the button layout
-  ## (e.g. on-screen displays).
-  ## 
-  ## Button indices start at 0. Setting the feedback string on a button
-  ## that is reserved by the compositor (i.e. not belonging to any
-  ## wp_tablet_pad_group) does not generate an error but the compositor
-  ## is free to ignore the request.
-  ## 
-  ## The provided string 'description' is a UTF-8 encoded string to be
-  ## associated with this ring, and is considered user-visible; general
-  ## internationalization rules apply.
-  ## 
-  ## The serial argument will be that of the last
-  ## wp_tablet_pad_group.mode_switch event received for the group of this
-  ## button. Requests providing other serials than the most recent one will
-  ## be ignored.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, button,
-                                 description, serial)
-
-proc destroy*(this: Zwp_tablet_pad_v2) =
-  ## Destroy the wp_tablet_pad object. Objects created from this object
-  ## are unaffected and should be destroyed separately.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
-
-proc get_surface*(this: Org_kde_plasma_shell; surface: Wl_surface): Org_kde_plasma_surface =
-  ## Create a shell surface for an existing surface.
-  ## 
-  ## Only one shell surface can be associated with a given
+  ## Clients can specify a namespace that defines the purpose of the layer
   ## surface.
   result = construct(wl_proxy_marshal_flags(this.proxy.raw, 0,
-      Org_kde_plasma_surface.iface, 1, 0, nil, surface), Org_kde_plasma_surface,
-                     `Org_kde_plasma_surface / dispatch`,
-                     `Org_kde_plasma_surface / Callbacks`)
+      Zwlr_layer_surface_v1.iface, 1, 0, nil, surface, output, layer, namespace),
+                     Zwlr_layer_surface_v1, `Zwlr_layer_surface_v1 / dispatch`,
+                     `Zwlr_layer_surface_v1 / Callbacks`)
 
-proc destroy*(this: Org_kde_plasma_surface) =
-  ## The org_kde_plasma_surface interface is removed from the
-  ## wl_surface object that was turned into a shell surface with the
-  ## org_kde_plasma_shell.get_surface request.
-  ## The shell surface role is lost and wl_surface is unmapped.
+proc destroy*(this: Zwlr_layer_shell_v1) =
+  ## This request indicates that the client will not use the layer_shell
+  ## object any more. Objects that have been created through this instance
+  ## are not affected.
   destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
 
-proc set_output*(this: Org_kde_plasma_surface; output: Wl_output) =
-  ## Assign an output to this shell surface.
-  ## The compositor will use this information to set the position
-  ## when org_kde_plasma_surface.set_position request is
-  ## called.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 0, output)
+proc set_size*(this: Zwlr_layer_surface_v1; width: uint32; height: uint32) =
+  ## Sets the size of the surface in surface-local coordinates. The
+  ## compositor will display the surface centered with respect to its
+  ## anchors.
+  ## 
+  ## If you pass 0 for either value, the compositor will assign it and
+  ## inform you of the assignment in the configure event. You must set your
+  ## anchor to opposite edges in the dimensions you omit; not doing so is a
+  ## protocol error. Both values are 0 by default.
+  ## 
+  ## Size is double-buffered, see wl_surface.commit.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, width, height)
 
-proc set_position*(this: Org_kde_plasma_surface; x: int32; y: int32) =
-  ## Move the surface to new coordinates.
+proc set_anchor*(this: Zwlr_layer_surface_v1;
+                 anchor: `Zwlr_layer_surface_v1 / Anchor`) =
+  ## Requests that the compositor anchor the surface to the specified edges
+  ## and corners. If two orthogonal edges are specified (e.g. 'top' and
+  ## 'left'), then the anchor point will be the intersection of the edges
+  ## (e.g. the top left corner of the output); otherwise the anchor point
+  ## will be centered on that edge, or in the center if none is specified.
   ## 
-  ## Coordinates are global, for example 50,50 for a 1920,0+1920x1080 output
-  ## is 1970,50 in global coordinates space.
-  ## 
-  ## Use org_kde_plasma_surface.set_output to assign an output
-  ## to this surface.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 2, nil, 1, 0, x, y)
+  ## Anchor is double-buffered, see wl_surface.commit.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 0, anchor)
 
-proc set_role*(this: Org_kde_plasma_surface; role: uint32) =
-  ## Assign a role to a shell surface.
+proc set_exclusive_zone*(this: Zwlr_layer_surface_v1; zone: int32) =
+  ## Requests that the compositor avoids occluding an area with other
+  ## surfaces. The compositor's use of this information is
+  ## implementation-dependent - do not assume that this region will not
+  ## actually be occluded.
   ## 
-  ## The compositor handles surfaces depending on their role.
-  ## See the explanation below.
+  ## A positive value is only meaningful if the surface is anchored to one
+  ## edge or an edge and both perpendicular edges. If the surface is not
+  ## anchored, anchored to only two perpendicular edges (a corner), anchored
+  ## to only two parallel edges or anchored to all edges, a positive value
+  ## will be treated the same as zero.
   ## 
-  ## This request fails if the surface already has a role, this means
-  ## the surface role may be assigned only once.
+  ## A positive zone is the distance from the edge in surface-local
+  ## coordinates to consider exclusive.
   ## 
-  ## == Surfaces with splash role ==
+  ## Surfaces that do not wish to have an exclusive zone may instead specify
+  ## how they should interact with surfaces that do. If set to zero, the
+  ## surface indicates that it would like to be moved to avoid occluding
+  ## surfaces with a positive exclusive zone. If set to -1, the surface
+  ## indicates that it would not like to be moved to accommodate for other
+  ## surfaces, and the compositor should extend it all the way to the edges
+  ## it is anchored to.
   ## 
-  ## Splash surfaces are placed above every other surface during the
-  ## shell startup phase.
+  ## For example, a panel might set its exclusive zone to 10, so that
+  ## maximized shell surfaces are not shown on top of it. A notification
+  ## might set its exclusive zone to 0, so that it is moved to avoid
+  ## occluding the panel, but shell surfaces are shown underneath it. A
+  ## wallpaper or lock screen might set their exclusive zone to -1, so that
+  ## they stretch below or over the panel.
   ## 
-  ## The surfaces are placed according to the output coordinates.
-  ## No size is imposed to those surfaces, the shell has to resize
-  ## them according to output size.
+  ## The default value is 0.
   ## 
-  ## These surfaces are meant to hide the desktop during the startup
-  ## phase so that the user will always see a ready to work desktop.
-  ## 
-  ## A shell might not create splash surfaces if the compositor reveals
-  ## the desktop in an alternative fashion, for example with a fade
-  ## in effect.
-  ## 
-  ## That depends on how much time the desktop usually need to prepare
-  ## the workspace or specific design decisions.
-  ## This specification doesn't impose any particular design.
-  ## 
-  ## When the startup phase is finished, the shell will send the
-  ## org_kde_plasma.desktop_ready request to the compositor.
-  ## 
-  ## == Surfaces with desktop role ==
-  ## 
-  ## Desktop surfaces are placed below all other surfaces and are used
-  ## to show the actual desktop view with icons, search results or
-  ## controls the user will interact with. What to show depends on the
-  ## shell implementation.
-  ## 
-  ## The surfaces are placed according to the output coordinates.
-  ## No size is imposed to those surfaces, the shell has to resize
-  ## them according to output size.
-  ## 
-  ## Only one surface per output can have the desktop role.
-  ## 
-  ## == Surfaces with dashboard role ==
-  ## 
-  ## Dashboard surfaces are placed above desktop surfaces and are used to
-  ## show additional widgets and controls.
-  ## 
-  ## The surfaces are placed according to the output coordinates.
-  ## No size is imposed to those surfaces, the shell has to resize
-  ## them according to output size.
-  ## 
-  ## Only one surface per output can have the dashboard role.
-  ## 
-  ## == Surfaces with config role ==
-  ## 
-  ## A configuration surface is shown when the user wants to configure
-  ## panel or desktop views.
-  ## 
-  ## Only one surface per output can have the config role.
-  ## 
-  ## TODO: This should grab the input like popup menus, right?
-  ## 
-  ## == Surfaces with overlay role ==
-  ## 
-  ## Overlays are special surfaces that shows for a limited amount
-  ## of time.  Such surfaces are useful to display things like volume,
-  ## brightness and status changes.
-  ## 
-  ## Compositors may decide to show those surfaces in a layer above
-  ## all surfaces, even full screen ones if so is desired.
-  ## 
-  ## == Surfaces with notification role ==
-  ## 
-  ## Notification surfaces display informative content for a limited
-  ## amount of time.  The compositor may decide to show them in a corner
-  ## depending on the configuration.
-  ## 
-  ## These surfaces are shown in a layer above all other surfaces except
-  ## for full screen ones.
-  ## 
-  ## == Surfaces with lock role ==
-  ## 
-  ## The lock surface is shown by the compositor when the session is
-  ## locked, users interact with it to unlock the session.
-  ## 
-  ## Compositors should move lock surfaces to 0,0 in output
-  ## coordinates space and hide all other surfaces for security sake.
-  ## For the same reason it is recommended that clients make the
-  ## lock surface as big as the screen.
-  ## 
-  ## Only one surface per output can have the lock role.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 3, nil, 1, 0, role)
+  ## Exclusive zone is double-buffered, see wl_surface.commit.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 2, nil, 1, 0, zone)
 
-proc set_panel_behavior*(this: Org_kde_plasma_surface; flag: uint32) =
-  ## Set flags bitmask as described by the flag enum.
-  ## Pass 0 to unset any flag, the surface will adjust its behavior to
-  ## the default.
+proc set_margin*(this: Zwlr_layer_surface_v1; top: int32; right: int32;
+                 bottom: int32; left: int32) =
+  ## Requests that the surface be placed some distance away from the anchor
+  ## point on the output, in surface-local coordinates. Setting this value
+  ## for edges you are not anchored to has no effect.
   ## 
-  ## Deprecated in Plasma 6. Setting this flag will have no effect. Applications should use layer shell where appropriate.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 4, nil, 1, 0, flag)
-
-proc set_skip_taskbar*(this: Org_kde_plasma_surface; skip: uint32) =
-  ## Setting this bit to the window, will make it say it prefers to not be listed in the taskbar. Taskbar implementations may or may not follow this hint.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 5, nil, 1, 0, skip)
-
-proc panel_auto_hide_hide*(this: Org_kde_plasma_surface) =
-  ## A panel surface with panel_behavior auto_hide can perform this request to hide the panel
-  ## on a screen edge without unmapping it. The compositor informs the client about the panel
-  ## being hidden with the event auto_hidden_panel_hidden.
+  ## The exclusive zone includes the margin.
   ## 
-  ## The compositor will restore the visibility state of the
-  ## surface when the pointer touches the screen edge the panel borders. Once the compositor restores
-  ## the visibility the event auto_hidden_panel_shown will be sent. This event will also be sent
-  ## if the compositor is unable to hide the panel.
+  ## Margin is double-buffered, see wl_surface.commit.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 3, nil, 1, 0, top, right,
+                                 bottom, left)
+
+proc set_keyboard_interactivity*(this: Zwlr_layer_surface_v1;
+    keyboard_interactivity: `Zwlr_layer_surface_v1 / Keyboard_interactivity`) =
+  ## Set how keyboard events are delivered to this surface. By default,
+  ## layer shell surfaces do not receive keyboard events; this request can
+  ## be used to change this.
   ## 
-  ## The client can also request to show the panel again with the request panel_auto_hide_show.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 6, nil, 1, 0)
+  ## This setting is inherited by child surfaces set by the get_popup
+  ## request.
+  ## 
+  ## Layer surfaces receive pointer, touch, and tablet events normally. If
+  ## you do not want to receive them, set the input region on your surface
+  ## to an empty region.
+  ## 
+  ## Keyboard interactivity is double-buffered, see wl_surface.commit.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 4, nil, 1, 0,
+                                 keyboard_interactivity)
 
-proc panel_auto_hide_show*(this: Org_kde_plasma_surface) =
-  ## A panel surface with panel_behavior auto_hide can perform this request to show the panel
-  ## again which got hidden with panel_auto_hide_hide.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 7, nil, 1, 0)
+proc get_popup*(this: Zwlr_layer_surface_v1; popup: Xdg_popup) =
+  ## This assigns an xdg_popup's parent to this layer_surface.  This popup
+  ## should have been created via xdg_surface::get_popup with the parent set
+  ## to NULL, and this request must be invoked before committing the popup's
+  ## initial state.
+  ## 
+  ## See the documentation of xdg_popup for more details about what an
+  ## xdg_popup is and how it is used.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 5, nil, 1, 0, popup)
 
-proc set_panel_takes_focus*(this: Org_kde_plasma_surface; takes_focus: uint32) =
-  ## By default various org_kde_plasma_surface roles do not take focus and cannot be
-  ## activated. With this request the compositor can be instructed to pass focus also to this
-  ## org_kde_plasma_surface.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 8, nil, 1, 0, takes_focus)
+proc ack_configure*(this: Zwlr_layer_surface_v1; serial: uint32) =
+  ## When a configure event is received, if a client commits the
+  ## surface in response to the configure event, then the client
+  ## must make an ack_configure request sometime before the commit
+  ## request, passing along the serial of the configure event.
+  ## 
+  ## If the client receives multiple configure events before it
+  ## can respond to one, it only has to ack the last configure event.
+  ## 
+  ## A client is not required to commit immediately after sending
+  ## an ack_configure request - it may even ack_configure several times
+  ## before its next surface commit.
+  ## 
+  ## A client may send multiple ack_configure requests before committing, but
+  ## only the last request sent before a commit indicates which configure
+  ## event the client really is responding to.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 6, nil, 1, 0, serial)
 
-proc set_skip_switcher*(this: Org_kde_plasma_surface; skip: uint32) =
-  ## Setting this bit will indicate that the window prefers not to be listed in a switcher.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 9, nil, 1, 0, skip)
-
-proc open_under_cursor*(this: Org_kde_plasma_surface) =
-  ## Request the initial position of this surface to be under the current
-  ## cursor position. Has to be called before attaching any buffer to this surface.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 10, nil, 1, 0)
-
-proc destroy*(this: Wp_cursor_shape_manager_v1) =
-  ## Destroy the cursor shape manager.
+proc destroy*(this: Zwlr_layer_surface_v1) =
+  ## This request destroys the layer surface.
   destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 7, nil, 1, 1)
 
-proc get_pointer*(this: Wp_cursor_shape_manager_v1; pointer: Wl_pointer): Wp_cursor_shape_device_v1 =
-  ## Obtain a wp_cursor_shape_device_v1 for a wl_pointer object.
-  result = construct(wl_proxy_marshal_flags(this.proxy.raw, 1,
-      Wp_cursor_shape_device_v1.iface, 1, 0, nil, pointer),
-                     Wp_cursor_shape_device_v1,
-                     `Wp_cursor_shape_device_v1 / dispatch`,
-                     `Wp_cursor_shape_device_v1 / Callbacks`)
-
-proc get_tablet_tool_v2*(this: Wp_cursor_shape_manager_v1;
-                         tablet_tool: Zwp_tablet_tool_v2): Wp_cursor_shape_device_v1 =
-  ## Obtain a wp_cursor_shape_device_v1 for a zwp_tablet_tool_v2 object.
-  result = construct(wl_proxy_marshal_flags(this.proxy.raw, 2,
-      Wp_cursor_shape_device_v1.iface, 1, 0, nil, tablet_tool),
-                     Wp_cursor_shape_device_v1,
-                     `Wp_cursor_shape_device_v1 / dispatch`,
-                     `Wp_cursor_shape_device_v1 / Callbacks`)
-
-proc destroy*(this: Wp_cursor_shape_device_v1) =
-  ## Destroy the cursor shape device.
+proc set_layer*(this: Zwlr_layer_surface_v1; layer: `Zwlr_layer_shell_v1 / Layer`) =
+  ## Change the layer that the surface is rendered on.
   ## 
-  ## The device cursor shape remains unchanged.
-  destroyCallbacks(this.proxy)
-  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
-
-proc set_shape*(this: Wp_cursor_shape_device_v1; serial: uint32;
-                shape: `Wp_cursor_shape_device_v1 / Shape`) =
-  ## Sets the device cursor to the specified shape. The compositor will
-  ## change the cursor image based on the specified shape.
-  ## 
-  ## The cursor actually changes only if the input device focus is one of
-  ## the requesting client's surfaces. If any, the previous cursor image
-  ## (surface or shape) is replaced.
-  ## 
-  ## The "shape" argument must be a valid enum entry, otherwise the
-  ## invalid_shape protocol error is raised.
-  ## 
-  ## This is similar to the wl_pointer.set_cursor and
-  ## zwp_tablet_tool_v2.set_cursor requests, but this request accepts a
-  ## shape instead of contents in the form of a surface. Clients can mix
-  ## set_cursor and set_shape requests.
-  ## 
-  ## The serial parameter must match the latest wl_pointer.enter or
-  ## zwp_tablet_tool_v2.proximity_in serial number sent to the client.
-  ## Otherwise the request will be ignored.
-  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 0, serial, shape)
+  ## Layer is double-buffered, see wl_surface.commit.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 8, nil, 1, 0, layer)
 
 proc destroy*(this: Xdg_wm_base) =
   ## Destroy this xdg_wm_base object.
@@ -3560,6 +3356,182 @@ proc reposition*(this: Xdg_popup; positioner: Xdg_positioner; token: uint32) =
   ## resized, but not in response to a configure event, the client should
   ## send an xdg_positioner.set_parent_size request.
   discard wl_proxy_marshal_flags(this.proxy.raw, 2, nil, 1, 0, positioner, token)
+
+proc get_surface*(this: Org_kde_plasma_shell; surface: Wl_surface): Org_kde_plasma_surface =
+  ## Create a shell surface for an existing surface.
+  ## 
+  ## Only one shell surface can be associated with a given
+  ## surface.
+  result = construct(wl_proxy_marshal_flags(this.proxy.raw, 0,
+      Org_kde_plasma_surface.iface, 1, 0, nil, surface), Org_kde_plasma_surface,
+                     `Org_kde_plasma_surface / dispatch`,
+                     `Org_kde_plasma_surface / Callbacks`)
+
+proc destroy*(this: Org_kde_plasma_surface) =
+  ## The org_kde_plasma_surface interface is removed from the
+  ## wl_surface object that was turned into a shell surface with the
+  ## org_kde_plasma_shell.get_surface request.
+  ## The shell surface role is lost and wl_surface is unmapped.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+
+proc set_output*(this: Org_kde_plasma_surface; output: Wl_output) =
+  ## Assign an output to this shell surface.
+  ## The compositor will use this information to set the position
+  ## when org_kde_plasma_surface.set_position request is
+  ## called.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 0, output)
+
+proc set_position*(this: Org_kde_plasma_surface; x: int32; y: int32) =
+  ## Move the surface to new coordinates.
+  ## 
+  ## Coordinates are global, for example 50,50 for a 1920,0+1920x1080 output
+  ## is 1970,50 in global coordinates space.
+  ## 
+  ## Use org_kde_plasma_surface.set_output to assign an output
+  ## to this surface.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 2, nil, 1, 0, x, y)
+
+proc set_role*(this: Org_kde_plasma_surface; role: uint32) =
+  ## Assign a role to a shell surface.
+  ## 
+  ## The compositor handles surfaces depending on their role.
+  ## See the explanation below.
+  ## 
+  ## This request fails if the surface already has a role, this means
+  ## the surface role may be assigned only once.
+  ## 
+  ## == Surfaces with splash role ==
+  ## 
+  ## Splash surfaces are placed above every other surface during the
+  ## shell startup phase.
+  ## 
+  ## The surfaces are placed according to the output coordinates.
+  ## No size is imposed to those surfaces, the shell has to resize
+  ## them according to output size.
+  ## 
+  ## These surfaces are meant to hide the desktop during the startup
+  ## phase so that the user will always see a ready to work desktop.
+  ## 
+  ## A shell might not create splash surfaces if the compositor reveals
+  ## the desktop in an alternative fashion, for example with a fade
+  ## in effect.
+  ## 
+  ## That depends on how much time the desktop usually need to prepare
+  ## the workspace or specific design decisions.
+  ## This specification doesn't impose any particular design.
+  ## 
+  ## When the startup phase is finished, the shell will send the
+  ## org_kde_plasma.desktop_ready request to the compositor.
+  ## 
+  ## == Surfaces with desktop role ==
+  ## 
+  ## Desktop surfaces are placed below all other surfaces and are used
+  ## to show the actual desktop view with icons, search results or
+  ## controls the user will interact with. What to show depends on the
+  ## shell implementation.
+  ## 
+  ## The surfaces are placed according to the output coordinates.
+  ## No size is imposed to those surfaces, the shell has to resize
+  ## them according to output size.
+  ## 
+  ## Only one surface per output can have the desktop role.
+  ## 
+  ## == Surfaces with dashboard role ==
+  ## 
+  ## Dashboard surfaces are placed above desktop surfaces and are used to
+  ## show additional widgets and controls.
+  ## 
+  ## The surfaces are placed according to the output coordinates.
+  ## No size is imposed to those surfaces, the shell has to resize
+  ## them according to output size.
+  ## 
+  ## Only one surface per output can have the dashboard role.
+  ## 
+  ## == Surfaces with config role ==
+  ## 
+  ## A configuration surface is shown when the user wants to configure
+  ## panel or desktop views.
+  ## 
+  ## Only one surface per output can have the config role.
+  ## 
+  ## TODO: This should grab the input like popup menus, right?
+  ## 
+  ## == Surfaces with overlay role ==
+  ## 
+  ## Overlays are special surfaces that shows for a limited amount
+  ## of time.  Such surfaces are useful to display things like volume,
+  ## brightness and status changes.
+  ## 
+  ## Compositors may decide to show those surfaces in a layer above
+  ## all surfaces, even full screen ones if so is desired.
+  ## 
+  ## == Surfaces with notification role ==
+  ## 
+  ## Notification surfaces display informative content for a limited
+  ## amount of time.  The compositor may decide to show them in a corner
+  ## depending on the configuration.
+  ## 
+  ## These surfaces are shown in a layer above all other surfaces except
+  ## for full screen ones.
+  ## 
+  ## == Surfaces with lock role ==
+  ## 
+  ## The lock surface is shown by the compositor when the session is
+  ## locked, users interact with it to unlock the session.
+  ## 
+  ## Compositors should move lock surfaces to 0,0 in output
+  ## coordinates space and hide all other surfaces for security sake.
+  ## For the same reason it is recommended that clients make the
+  ## lock surface as big as the screen.
+  ## 
+  ## Only one surface per output can have the lock role.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 3, nil, 1, 0, role)
+
+proc set_panel_behavior*(this: Org_kde_plasma_surface; flag: uint32) =
+  ## Set flags bitmask as described by the flag enum.
+  ## Pass 0 to unset any flag, the surface will adjust its behavior to
+  ## the default.
+  ## 
+  ## Deprecated in Plasma 6. Setting this flag will have no effect. Applications should use layer shell where appropriate.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 4, nil, 1, 0, flag)
+
+proc set_skip_taskbar*(this: Org_kde_plasma_surface; skip: uint32) =
+  ## Setting this bit to the window, will make it say it prefers to not be listed in the taskbar. Taskbar implementations may or may not follow this hint.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 5, nil, 1, 0, skip)
+
+proc panel_auto_hide_hide*(this: Org_kde_plasma_surface) =
+  ## A panel surface with panel_behavior auto_hide can perform this request to hide the panel
+  ## on a screen edge without unmapping it. The compositor informs the client about the panel
+  ## being hidden with the event auto_hidden_panel_hidden.
+  ## 
+  ## The compositor will restore the visibility state of the
+  ## surface when the pointer touches the screen edge the panel borders. Once the compositor restores
+  ## the visibility the event auto_hidden_panel_shown will be sent. This event will also be sent
+  ## if the compositor is unable to hide the panel.
+  ## 
+  ## The client can also request to show the panel again with the request panel_auto_hide_show.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 6, nil, 1, 0)
+
+proc panel_auto_hide_show*(this: Org_kde_plasma_surface) =
+  ## A panel surface with panel_behavior auto_hide can perform this request to show the panel
+  ## again which got hidden with panel_auto_hide_hide.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 7, nil, 1, 0)
+
+proc set_panel_takes_focus*(this: Org_kde_plasma_surface; takes_focus: uint32) =
+  ## By default various org_kde_plasma_surface roles do not take focus and cannot be
+  ## activated. With this request the compositor can be instructed to pass focus also to this
+  ## org_kde_plasma_surface.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 8, nil, 1, 0, takes_focus)
+
+proc set_skip_switcher*(this: Org_kde_plasma_surface; skip: uint32) =
+  ## Setting this bit will indicate that the window prefers not to be listed in a switcher.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 9, nil, 1, 0, skip)
+
+proc open_under_cursor*(this: Org_kde_plasma_surface) =
+  ## Request the initial position of this surface to be under the current
+  ## cursor position. Has to be called before attaching any buffer to this surface.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 10, nil, 1, 0)
 
 proc sync*(this: Wl_display): Wl_callback =
   ## The sync request asks the server to emit the 'done' event
@@ -4552,6 +4524,221 @@ proc set_desync*(this: Wl_subsurface) =
   ## the cached state is applied on set_desync.
   discard wl_proxy_marshal_flags(this.proxy.raw, 5, nil, 1, 0)
 
+proc destroy*(this: Wp_cursor_shape_manager_v1) =
+  ## Destroy the cursor shape manager.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+
+proc get_pointer*(this: Wp_cursor_shape_manager_v1; pointer: Wl_pointer): Wp_cursor_shape_device_v1 =
+  ## Obtain a wp_cursor_shape_device_v1 for a wl_pointer object.
+  result = construct(wl_proxy_marshal_flags(this.proxy.raw, 1,
+      Wp_cursor_shape_device_v1.iface, 1, 0, nil, pointer),
+                     Wp_cursor_shape_device_v1,
+                     `Wp_cursor_shape_device_v1 / dispatch`,
+                     `Wp_cursor_shape_device_v1 / Callbacks`)
+
+proc get_tablet_tool_v2*(this: Wp_cursor_shape_manager_v1;
+                         tablet_tool: Zwp_tablet_tool_v2): Wp_cursor_shape_device_v1 =
+  ## Obtain a wp_cursor_shape_device_v1 for a zwp_tablet_tool_v2 object.
+  result = construct(wl_proxy_marshal_flags(this.proxy.raw, 2,
+      Wp_cursor_shape_device_v1.iface, 1, 0, nil, tablet_tool),
+                     Wp_cursor_shape_device_v1,
+                     `Wp_cursor_shape_device_v1 / dispatch`,
+                     `Wp_cursor_shape_device_v1 / Callbacks`)
+
+proc destroy*(this: Wp_cursor_shape_device_v1) =
+  ## Destroy the cursor shape device.
+  ## 
+  ## The device cursor shape remains unchanged.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+
+proc set_shape*(this: Wp_cursor_shape_device_v1; serial: uint32;
+                shape: `Wp_cursor_shape_device_v1 / Shape`) =
+  ## Sets the device cursor to the specified shape. The compositor will
+  ## change the cursor image based on the specified shape.
+  ## 
+  ## The cursor actually changes only if the input device focus is one of
+  ## the requesting client's surfaces. If any, the previous cursor image
+  ## (surface or shape) is replaced.
+  ## 
+  ## The "shape" argument must be a valid enum entry, otherwise the
+  ## invalid_shape protocol error is raised.
+  ## 
+  ## This is similar to the wl_pointer.set_cursor and
+  ## zwp_tablet_tool_v2.set_cursor requests, but this request accepts a
+  ## shape instead of contents in the form of a surface. Clients can mix
+  ## set_cursor and set_shape requests.
+  ## 
+  ## The serial parameter must match the latest wl_pointer.enter or
+  ## zwp_tablet_tool_v2.proximity_in serial number sent to the client.
+  ## Otherwise the request will be ignored.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 0, serial, shape)
+
+proc get_tablet_seat*(this: Zwp_tablet_manager_v2; seat: Wl_seat): Zwp_tablet_seat_v2 =
+  ## Get the wp_tablet_seat object for the given seat. This object
+  ## provides access to all graphics tablets in this seat.
+  result = construct(wl_proxy_marshal_flags(this.proxy.raw, 0,
+      Zwp_tablet_seat_v2.iface, 1, 0, nil, seat), Zwp_tablet_seat_v2,
+                     `Zwp_tablet_seat_v2 / dispatch`,
+                     `Zwp_tablet_seat_v2 / Callbacks`)
+
+proc destroy*(this: Zwp_tablet_manager_v2) =
+  ## Destroy the wp_tablet_manager object. Objects created from this
+  ## object are unaffected and should be destroyed separately.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
+
+proc destroy*(this: Zwp_tablet_seat_v2) =
+  ## Destroy the wp_tablet_seat object. Objects created from this
+  ## object are unaffected and should be destroyed separately.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+
+proc set_cursor*(this: Zwp_tablet_tool_v2; serial: uint32; surface: Wl_surface;
+                 hotspot_x: int32; hotspot_y: int32) =
+  ## Sets the surface of the cursor used for this tool on the given
+  ## tablet. This request only takes effect if the tool is in proximity
+  ## of one of the requesting client's surfaces or the surface parameter
+  ## is the current pointer surface. If there was a previous surface set
+  ## with this request it is replaced. If surface is NULL, the cursor
+  ## image is hidden.
+  ## 
+  ## The parameters hotspot_x and hotspot_y define the position of the
+  ## pointer surface relative to the pointer location. Its top-left corner
+  ## is always at (x, y) - (hotspot_x, hotspot_y), where (x, y) are the
+  ## coordinates of the pointer location, in surface-local coordinates.
+  ## 
+  ## On surface.attach requests to the pointer surface, hotspot_x and
+  ## hotspot_y are decremented by the x and y parameters passed to the
+  ## request. Attach must be confirmed by wl_surface.commit as usual.
+  ## 
+  ## The hotspot can also be updated by passing the currently set pointer
+  ## surface to this request with new values for hotspot_x and hotspot_y.
+  ## 
+  ## The current and pending input regions of the wl_surface are cleared,
+  ## and wl_surface.set_input_region is ignored until the wl_surface is no
+  ## longer used as the cursor. When the use as a cursor ends, the current
+  ## and pending input regions become undefined, and the wl_surface is
+  ## unmapped.
+  ## 
+  ## This request gives the surface the role of a wp_tablet_tool cursor. A
+  ## surface may only ever be used as the cursor surface for one
+  ## wp_tablet_tool. If the surface already has another role or has
+  ## previously been used as cursor surface for a different tool, a
+  ## protocol error is raised.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, serial, surface,
+                                 hotspot_x, hotspot_y)
+
+proc destroy*(this: Zwp_tablet_tool_v2) =
+  ## This destroys the client's resource for this tool object.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
+
+proc destroy*(this: Zwp_tablet_v2) =
+  ## This destroys the client's resource for this tablet object.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+
+proc set_feedback*(this: Zwp_tablet_pad_ring_v2; description: cstring;
+                   serial: uint32) =
+  ## Request that the compositor use the provided feedback string
+  ## associated with this ring. This request should be issued immediately
+  ## after a wp_tablet_pad_group.mode_switch event from the corresponding
+  ## group is received, or whenever the ring is mapped to a different
+  ## action. See wp_tablet_pad_group.mode_switch for more details.
+  ## 
+  ## Clients are encouraged to provide context-aware descriptions for
+  ## the actions associated with the ring; compositors may use this
+  ## information to offer visual feedback about the button layout
+  ## (eg. on-screen displays).
+  ## 
+  ## The provided string 'description' is a UTF-8 encoded string to be
+  ## associated with this ring, and is considered user-visible; general
+  ## internationalization rules apply.
+  ## 
+  ## The serial argument will be that of the last
+  ## wp_tablet_pad_group.mode_switch event received for the group of this
+  ## ring. Requests providing other serials than the most recent one will be
+  ## ignored.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, description,
+                                 serial)
+
+proc destroy*(this: Zwp_tablet_pad_ring_v2) =
+  ## This destroys the client's resource for this ring object.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
+
+proc set_feedback*(this: Zwp_tablet_pad_strip_v2; description: cstring;
+                   serial: uint32) =
+  ## Requests the compositor to use the provided feedback string
+  ## associated with this strip. This request should be issued immediately
+  ## after a wp_tablet_pad_group.mode_switch event from the corresponding
+  ## group is received, or whenever the strip is mapped to a different
+  ## action. See wp_tablet_pad_group.mode_switch for more details.
+  ## 
+  ## Clients are encouraged to provide context-aware descriptions for
+  ## the actions associated with the strip, and compositors may use this
+  ## information to offer visual feedback about the button layout
+  ## (eg. on-screen displays).
+  ## 
+  ## The provided string 'description' is a UTF-8 encoded string to be
+  ## associated with this ring, and is considered user-visible; general
+  ## internationalization rules apply.
+  ## 
+  ## The serial argument will be that of the last
+  ## wp_tablet_pad_group.mode_switch event received for the group of this
+  ## strip. Requests providing other serials than the most recent one will be
+  ## ignored.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, description,
+                                 serial)
+
+proc destroy*(this: Zwp_tablet_pad_strip_v2) =
+  ## This destroys the client's resource for this strip object.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
+
+proc destroy*(this: Zwp_tablet_pad_group_v2) =
+  ## Destroy the wp_tablet_pad_group object. Objects created from this object
+  ## are unaffected and should be destroyed separately.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 1)
+
+proc set_feedback*(this: Zwp_tablet_pad_v2; button: uint32;
+                   description: cstring; serial: uint32) =
+  ## Requests the compositor to use the provided feedback string
+  ## associated with this button. This request should be issued immediately
+  ## after a wp_tablet_pad_group.mode_switch event from the corresponding
+  ## group is received, or whenever a button is mapped to a different
+  ## action. See wp_tablet_pad_group.mode_switch for more details.
+  ## 
+  ## Clients are encouraged to provide context-aware descriptions for
+  ## the actions associated with each button, and compositors may use
+  ## this information to offer visual feedback on the button layout
+  ## (e.g. on-screen displays).
+  ## 
+  ## Button indices start at 0. Setting the feedback string on a button
+  ## that is reserved by the compositor (i.e. not belonging to any
+  ## wp_tablet_pad_group) does not generate an error but the compositor
+  ## is free to ignore the request.
+  ## 
+  ## The provided string 'description' is a UTF-8 encoded string to be
+  ## associated with this ring, and is considered user-visible; general
+  ## internationalization rules apply.
+  ## 
+  ## The serial argument will be that of the last
+  ## wp_tablet_pad_group.mode_switch event received for the group of this
+  ## button. Requests providing other serials than the most recent one will
+  ## be ignored.
+  discard wl_proxy_marshal_flags(this.proxy.raw, 0, nil, 1, 0, button,
+                                 description, serial)
+
+proc destroy*(this: Zwp_tablet_pad_v2) =
+  ## Destroy the wp_tablet_pad object. Objects created from this object
+  ## are unaffected and should be destroyed separately.
+  destroyCallbacks(this.proxy)
+  discard wl_proxy_marshal_flags(this.proxy.raw, 1, nil, 1, 1)
+
 proc destroy*(this: Zxdg_decoration_manager_v1) =
   ## Destroy the decoration manager. This doesn't destroy objects created
   ## with the manager.
@@ -4608,634 +4795,39 @@ proc unset_mode*(this: Zxdg_toplevel_decoration_v1) =
   ## This request has the same semantics as set_mode.
   discard wl_proxy_marshal_flags(this.proxy.raw, 2, nil, 1, 0)
 
-template onTablet_added*(this: Zwp_tablet_seat_v2; body) =
-  ## This event is sent whenever a new tablet becomes available on this
-  ## seat. This event only provides the object id of the tablet, any
-  ## static information about the tablet (device name, vid/pid, etc.) is
-  ## sent through the wp_tablet interface.
-  cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](this.proxy.raw.impl).tablet_added = proc (
-      id {.inject.}: Zwp_tablet_v2) =
+template onConfigure*(this: Zwlr_layer_surface_v1; body) =
+  ## The configure event asks the client to resize its surface.
+  ## 
+  ## Clients should arrange their surface for the new states, and then send
+  ## an ack_configure request with the serial sent in this configure event at
+  ## some point before committing the new surface.
+  ## 
+  ## The client is free to dismiss all but the last configure event it
+  ## received.
+  ## 
+  ## The width and height arguments specify the size of the window in
+  ## surface-local coordinates.
+  ## 
+  ## The size is a hint, in the sense that the client is free to ignore it if
+  ## it doesn't resize, pick a smaller size (to satisfy aspect ratio or
+  ## resize in steps of NxM pixels). If the client picks a smaller size and
+  ## is anchored to two opposite anchors (e.g. 'top' and 'bottom'), the
+  ## surface will be centered on this axis.
+  ## 
+  ## If the width or height arguments are zero, it means the client should
+  ## decide its own window dimension.
+  cast[ptr `Zwlr_layer_surface_v1 / Callbacks`](this.proxy.raw.impl).configure = proc (
+      serial {.inject.}: uint32; width {.inject.}: uint32;
+      height {.inject.}: uint32) =
     body
 
-template onTool_added*(this: Zwp_tablet_seat_v2; body) =
-  ## This event is sent whenever a tool that has not previously been used
-  ## with a tablet comes into use. This event only provides the object id
-  ## of the tool; any static information about the tool (capabilities,
-  ## type, etc.) is sent through the wp_tablet_tool interface.
-  cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](this.proxy.raw.impl).tool_added = proc (
-      id {.inject.}: Zwp_tablet_tool_v2) =
-    body
-
-template onPad_added*(this: Zwp_tablet_seat_v2; body) =
-  ## This event is sent whenever a new pad is known to the system. Typically,
-  ## pads are physically attached to tablets and a pad_added event is
-  ## sent immediately after the wp_tablet_seat.tablet_added.
-  ## However, some standalone pad devices logically attach to tablets at
-  ## runtime, and the client must wait for wp_tablet_pad.enter to know
-  ## the tablet a pad is attached to.
-  ## 
-  ## This event only provides the object id of the pad. All further
-  ## features (buttons, strips, rings) are sent through the wp_tablet_pad
-  ## interface.
-  cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](this.proxy.raw.impl).pad_added = proc (
-      id {.inject.}: Zwp_tablet_pad_v2) =
-    body
-
-template onType*(this: Zwp_tablet_tool_v2; body) =
-  ## The tool type is the high-level type of the tool and usually decides
-  ## the interaction expected from this tool.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_tool.done event.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).`type` = proc (
-      tool_type {.inject.}: `Zwp_tablet_tool_v2 / Type`) =
-    body
-
-template onHardware_serial*(this: Zwp_tablet_tool_v2; body) =
-  ## If the physical tool can be identified by a unique 64-bit serial
-  ## number, this event notifies the client of this serial number.
-  ## 
-  ## If multiple tablets are available in the same seat and the tool is
-  ## uniquely identifiable by the serial number, that tool may move
-  ## between tablets.
-  ## 
-  ## Otherwise, if the tool has no serial number and this event is
-  ## missing, the tool is tied to the tablet it first comes into
-  ## proximity with. Even if the physical tool is used on multiple
-  ## tablets, separate wp_tablet_tool objects will be created, one per
-  ## tablet.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_tool.done event.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).hardware_serial = proc (
-      hardware_serial_hi {.inject.}: uint32;
-      hardware_serial_lo {.inject.}: uint32) =
-    body
-
-template onHardware_id_wacom*(this: Zwp_tablet_tool_v2; body) =
-  ## This event notifies the client of a hardware id available on this tool.
-  ## 
-  ## The hardware id is a device-specific 64-bit id that provides extra
-  ## information about the tool in use, beyond the wl_tool.type
-  ## enumeration. The format of the id is specific to tablets made by
-  ## Wacom Inc. For example, the hardware id of a Wacom Grip
-  ## Pen (a stylus) is 0x802.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_tool.done event.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).hardware_id_wacom = proc (
-      hardware_id_hi {.inject.}: uint32; hardware_id_lo {.inject.}: uint32) =
-    body
-
-template onCapability*(this: Zwp_tablet_tool_v2; body) =
-  ## This event notifies the client of any capabilities of this tool,
-  ## beyond the main set of x/y axes and tip up/down detection.
-  ## 
-  ## One event is sent for each extra capability available on this tool.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_tool.done event.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).capability = proc (
-      capability {.inject.}: `Zwp_tablet_tool_v2 / Capability`) =
-    body
-
-template onDone*(this: Zwp_tablet_tool_v2; body) =
-  ## This event signals the end of the initial burst of descriptive
-  ## events. A client may consider the static description of the tool to
-  ## be complete and finalize initialization of the tool.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
-    body
-
-template onRemoved*(this: Zwp_tablet_tool_v2; body) =
-  ## This event is sent when the tool is removed from the system and will
-  ## send no further events. Should the physical tool come back into
-  ## proximity later, a new wp_tablet_tool object will be created.
-  ## 
-  ## It is compositor-dependent when a tool is removed. A compositor may
-  ## remove a tool on proximity out, tablet removal or any other reason.
-  ## A compositor may also keep a tool alive until shutdown.
-  ## 
-  ## If the tool is currently in proximity, a proximity_out event will be
-  ## sent before the removed event. See wp_tablet_tool.proximity_out for
-  ## the handling of any buttons logically down.
-  ## 
-  ## When this event is received, the client must wp_tablet_tool.destroy
-  ## the object.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).removed = proc () =
-    body
-
-template onProximity_in*(this: Zwp_tablet_tool_v2; body) =
-  ## Notification that this tool is focused on a certain surface.
-  ## 
-  ## This event can be received when the tool has moved from one surface to
-  ## another, or when the tool has come back into proximity above the
-  ## surface.
-  ## 
-  ## If any button is logically down when the tool comes into proximity,
-  ## the respective button event is sent after the proximity_in event but
-  ## within the same frame as the proximity_in event.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).proximity_in = proc (
-      serial {.inject.}: uint32; tablet {.inject.}: Zwp_tablet_v2;
-      surface {.inject.}: Wl_surface) =
-    body
-
-template onProximity_out*(this: Zwp_tablet_tool_v2; body) =
-  ## Notification that this tool has either left proximity, or is no
-  ## longer focused on a certain surface.
-  ## 
-  ## When the tablet tool leaves proximity of the tablet, button release
-  ## events are sent for each button that was held down at the time of
-  ## leaving proximity. These events are sent before the proximity_out
-  ## event but within the same wp_tablet.frame.
-  ## 
-  ## If the tool stays within proximity of the tablet, but the focus
-  ## changes from one surface to another, a button release event may not
-  ## be sent until the button is actually released or the tool leaves the
-  ## proximity of the tablet.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).proximity_out = proc () =
-    body
-
-template onDown*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever the tablet tool comes in contact with the surface of the
-  ## tablet.
-  ## 
-  ## If the tool is already in contact with the tablet when entering the
-  ## input region, the client owning said region will receive a
-  ## wp_tablet.proximity_in event, followed by a wp_tablet.down
-  ## event and a wp_tablet.frame event.
-  ## 
-  ## Note that this event describes logical contact, not physical
-  ## contact. On some devices, a compositor may not consider a tool in
-  ## logical contact until a minimum physical pressure threshold is
-  ## exceeded.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).down = proc (
-      serial {.inject.}: uint32) =
-    body
-
-template onUp*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever the tablet tool stops making contact with the surface of
-  ## the tablet, or when the tablet tool moves out of the input region
-  ## and the compositor grab (if any) is dismissed.
-  ## 
-  ## If the tablet tool moves out of the input region while in contact
-  ## with the surface of the tablet and the compositor does not have an
-  ## ongoing grab on the surface, the client owning said region will
-  ## receive a wp_tablet.up event, followed by a wp_tablet.proximity_out
-  ## event and a wp_tablet.frame event. If the compositor has an ongoing
-  ## grab on this device, this event sequence is sent whenever the grab
-  ## is dismissed in the future.
-  ## 
-  ## Note that this event describes logical contact, not physical
-  ## contact. On some devices, a compositor may not consider a tool out
-  ## of logical contact until physical pressure falls below a specific
-  ## threshold.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).up = proc () =
-    body
-
-template onMotion*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever a tablet tool moves.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).motion = proc (
-      x {.inject.}: float32; y {.inject.}: float32) =
-    body
-
-template onPressure*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever the pressure axis on a tool changes. The value of this
-  ## event is normalized to a value between 0 and 65535.
-  ## 
-  ## Note that pressure may be nonzero even when a tool is not in logical
-  ## contact. See the down and up events for more details.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).pressure = proc (
-      pressure {.inject.}: uint32) =
-    body
-
-template onDistance*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever the distance axis on a tool changes. The value of this
-  ## event is normalized to a value between 0 and 65535.
-  ## 
-  ## Note that distance may be nonzero even when a tool is not in logical
-  ## contact. See the down and up events for more details.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).distance = proc (
-      distance {.inject.}: uint32) =
-    body
-
-template onTilt*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever one or both of the tilt axes on a tool change. Each tilt
-  ## value is in degrees, relative to the z-axis of the tablet.
-  ## The angle is positive when the top of a tool tilts along the
-  ## positive x or y axis.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).tilt = proc (
-      tilt_x {.inject.}: float32; tilt_y {.inject.}: float32) =
-    body
-
-template onRotation*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever the z-rotation axis on the tool changes. The
-  ## rotation value is in degrees clockwise from the tool's
-  ## logical neutral position.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).rotation = proc (
-      degrees {.inject.}: float32) =
-    body
-
-template onSlider*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever the slider position on the tool changes. The
-  ## value is normalized between -65535 and 65535, with 0 as the logical
-  ## neutral position of the slider.
-  ## 
-  ## The slider is available on e.g. the Wacom Airbrush tool.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).slider = proc (
-      position {.inject.}: int32) =
-    body
-
-template onWheel*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever the wheel on the tool emits an event. This event
-  ## contains two values for the same axis change. The degrees value is
-  ## in the same orientation as the wl_pointer.vertical_scroll axis. The
-  ## clicks value is in discrete logical clicks of the mouse wheel. This
-  ## value may be zero if the movement of the wheel was less
-  ## than one logical click.
-  ## 
-  ## Clients should choose either value and avoid mixing degrees and
-  ## clicks. The compositor may accumulate values smaller than a logical
-  ## click and emulate click events when a certain threshold is met.
-  ## Thus, wl_tablet_tool.wheel events with non-zero clicks values may
-  ## have different degrees values.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).wheel = proc (
-      degrees {.inject.}: float32; clicks {.inject.}: int32) =
-    body
-
-template onButton*(this: Zwp_tablet_tool_v2; body) =
-  ## Sent whenever a button on the tool is pressed or released.
-  ## 
-  ## If a button is held down when the tool moves in or out of proximity,
-  ## button events are generated by the compositor. See
-  ## wp_tablet_tool.proximity_in and wp_tablet_tool.proximity_out for
-  ## details.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).button = proc (
-      serial {.inject.}: uint32; button {.inject.}: uint32;
-      state {.inject.}: `Zwp_tablet_tool_v2 / Button_state`) =
-    body
-
-template onFrame*(this: Zwp_tablet_tool_v2; body) =
-  ## Marks the end of a series of axis and/or button updates from the
-  ## tablet. The Wayland protocol requires axis updates to be sent
-  ## sequentially, however all events within a frame should be considered
-  ## one hardware event.
-  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).frame = proc (
-      time {.inject.}: uint32) =
-    body
-
-template onName*(this: Zwp_tablet_v2; body) =
-  ## A descriptive name for the tablet device.
-  ## 
-  ## If the device has no descriptive name, this event is not sent.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet.done event.
-  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).name = proc (
-      name {.inject.}: cstring) =
-    body
-
-template onId*(this: Zwp_tablet_v2; body) =
-  ## The USB vendor and product IDs for the tablet device.
-  ## 
-  ## If the device has no USB vendor/product ID, this event is not sent.
-  ## This can happen for virtual devices or non-USB devices, for instance.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet.done event.
-  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).id = proc (
-      vid {.inject.}: uint32; pid {.inject.}: uint32) =
-    body
-
-template onPath*(this: Zwp_tablet_v2; body) =
-  ## A system-specific device path that indicates which device is behind
-  ## this wp_tablet. This information may be used to gather additional
-  ## information about the device, e.g. through libwacom.
-  ## 
-  ## A device may have more than one device path. If so, multiple
-  ## wp_tablet.path events are sent. A device may be emulated and not
-  ## have a device path, and in that case this event will not be sent.
-  ## 
-  ## The format of the path is unspecified, it may be a device node, a
-  ## sysfs path, or some other identifier. It is up to the client to
-  ## identify the string provided.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet.done event.
-  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).path = proc (
-      path {.inject.}: cstring) =
-    body
-
-template onDone*(this: Zwp_tablet_v2; body) =
-  ## This event is sent immediately to signal the end of the initial
-  ## burst of descriptive events. A client may consider the static
-  ## description of the tablet to be complete and finalize initialization
-  ## of the tablet.
-  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
-    body
-
-template onRemoved*(this: Zwp_tablet_v2; body) =
-  ## Sent when the tablet has been removed from the system. When a tablet
-  ## is removed, some tools may be removed.
-  ## 
-  ## When this event is received, the client must wp_tablet.destroy
-  ## the object.
-  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).removed = proc () =
-    body
-
-template onSource*(this: Zwp_tablet_pad_ring_v2; body) =
-  ## Source information for ring events.
-  ## 
-  ## This event does not occur on its own. It is sent before a
-  ## wp_tablet_pad_ring.frame event and carries the source information
-  ## for all events within that frame.
-  ## 
-  ## The source specifies how this event was generated. If the source is
-  ## wp_tablet_pad_ring.source.finger, a wp_tablet_pad_ring.stop event
-  ## will be sent when the user lifts the finger off the device.
-  ## 
-  ## This event is optional. If the source is unknown for an interaction,
-  ## no event is sent.
-  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).source = proc (
-      source {.inject.}: `Zwp_tablet_pad_ring_v2 / Source`) =
-    body
-
-template onAngle*(this: Zwp_tablet_pad_ring_v2; body) =
-  ## Sent whenever the angle on a ring changes.
-  ## 
-  ## The angle is provided in degrees clockwise from the logical
-  ## north of the ring in the pad's current rotation.
-  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).angle = proc (
-      degrees {.inject.}: float32) =
-    body
-
-template onStop*(this: Zwp_tablet_pad_ring_v2; body) =
-  ## Stop notification for ring events.
-  ## 
-  ## For some wp_tablet_pad_ring.source types, a wp_tablet_pad_ring.stop
-  ## event is sent to notify a client that the interaction with the ring
-  ## has terminated. This enables the client to implement kinetic scrolling.
-  ## See the wp_tablet_pad_ring.source documentation for information on
-  ## when this event may be generated.
-  ## 
-  ## Any wp_tablet_pad_ring.angle events with the same source after this
-  ## event should be considered as the start of a new interaction.
-  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).stop = proc () =
-    body
-
-template onFrame*(this: Zwp_tablet_pad_ring_v2; body) =
-  ## Indicates the end of a set of ring events that logically belong
-  ## together. A client is expected to accumulate the data in all events
-  ## within the frame before proceeding.
-  ## 
-  ## All wp_tablet_pad_ring events before a wp_tablet_pad_ring.frame event belong
-  ## logically together. For example, on termination of a finger interaction
-  ## on a ring the compositor will send a wp_tablet_pad_ring.source event,
-  ## a wp_tablet_pad_ring.stop event and a wp_tablet_pad_ring.frame event.
-  ## 
-  ## A wp_tablet_pad_ring.frame event is sent for every logical event
-  ## group, even if the group only contains a single wp_tablet_pad_ring
-  ## event. Specifically, a client may get a sequence: angle, frame,
-  ## angle, frame, etc.
-  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).frame = proc (
-      time {.inject.}: uint32) =
-    body
-
-template onSource*(this: Zwp_tablet_pad_strip_v2; body) =
-  ## Source information for strip events.
-  ## 
-  ## This event does not occur on its own. It is sent before a
-  ## wp_tablet_pad_strip.frame event and carries the source information
-  ## for all events within that frame.
-  ## 
-  ## The source specifies how this event was generated. If the source is
-  ## wp_tablet_pad_strip.source.finger, a wp_tablet_pad_strip.stop event
-  ## will be sent when the user lifts their finger off the device.
-  ## 
-  ## This event is optional. If the source is unknown for an interaction,
-  ## no event is sent.
-  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).source = proc (
-      source {.inject.}: `Zwp_tablet_pad_strip_v2 / Source`) =
-    body
-
-template onPosition*(this: Zwp_tablet_pad_strip_v2; body) =
-  ## Sent whenever the position on a strip changes.
-  ## 
-  ## The position is normalized to a range of [0, 65535], the 0-value
-  ## represents the top-most and/or left-most position of the strip in
-  ## the pad's current rotation.
-  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).position = proc (
-      position {.inject.}: uint32) =
-    body
-
-template onStop*(this: Zwp_tablet_pad_strip_v2; body) =
-  ## Stop notification for strip events.
-  ## 
-  ## For some wp_tablet_pad_strip.source types, a wp_tablet_pad_strip.stop
-  ## event is sent to notify a client that the interaction with the strip
-  ## has terminated. This enables the client to implement kinetic
-  ## scrolling. See the wp_tablet_pad_strip.source documentation for
-  ## information on when this event may be generated.
-  ## 
-  ## Any wp_tablet_pad_strip.position events with the same source after this
-  ## event should be considered as the start of a new interaction.
-  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).stop = proc () =
-    body
-
-template onFrame*(this: Zwp_tablet_pad_strip_v2; body) =
-  ## Indicates the end of a set of events that represent one logical
-  ## hardware strip event. A client is expected to accumulate the data
-  ## in all events within the frame before proceeding.
-  ## 
-  ## All wp_tablet_pad_strip events before a wp_tablet_pad_strip.frame event belong
-  ## logically together. For example, on termination of a finger interaction
-  ## on a strip the compositor will send a wp_tablet_pad_strip.source event,
-  ## a wp_tablet_pad_strip.stop event and a wp_tablet_pad_strip.frame
-  ## event.
-  ## 
-  ## A wp_tablet_pad_strip.frame event is sent for every logical event
-  ## group, even if the group only contains a single wp_tablet_pad_strip
-  ## event. Specifically, a client may get a sequence: position, frame,
-  ## position, frame, etc.
-  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).frame = proc (
-      time {.inject.}: uint32) =
-    body
-
-template onButtons*(this: Zwp_tablet_pad_group_v2; body) =
-  ## Sent on wp_tablet_pad_group initialization to announce the available
-  ## buttons in the group. Button indices start at 0, a button may only be
-  ## in one group at a time.
-  ## 
-  ## This event is first sent in the initial burst of events before the
-  ## wp_tablet_pad_group.done event.
-  ## 
-  ## Some buttons are reserved by the compositor. These buttons may not be
-  ## assigned to any wp_tablet_pad_group. Compositors may broadcast this
-  ## event in the case of changes to the mapping of these reserved buttons.
-  ## If the compositor happens to reserve all buttons in a group, this event
-  ## will be sent with an empty array.
-  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).buttons = proc (
-      buttons {.inject.}: Wl_array) =
-    body
-
-template onRing*(this: Zwp_tablet_pad_group_v2; body) =
-  ## Sent on wp_tablet_pad_group initialization to announce available rings.
-  ## One event is sent for each ring available on this pad group.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_pad_group.done event.
-  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).ring = proc (
-      ring {.inject.}: Zwp_tablet_pad_ring_v2) =
-    body
-
-template onStrip*(this: Zwp_tablet_pad_group_v2; body) =
-  ## Sent on wp_tablet_pad initialization to announce available strips.
-  ## One event is sent for each strip available on this pad group.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_pad_group.done event.
-  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).strip = proc (
-      strip {.inject.}: Zwp_tablet_pad_strip_v2) =
-    body
-
-template onModes*(this: Zwp_tablet_pad_group_v2; body) =
-  ## Sent on wp_tablet_pad_group initialization to announce that the pad
-  ## group may switch between modes. A client may use a mode to store a
-  ## specific configuration for buttons, rings and strips and use the
-  ## wl_tablet_pad_group.mode_switch event to toggle between these
-  ## configurations. Mode indices start at 0.
-  ## 
-  ## Switching modes is compositor-dependent. See the
-  ## wp_tablet_pad_group.mode_switch event for more details.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_pad_group.done event. This event is only sent when more than
-  ## more than one mode is available.
-  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).modes = proc (
-      modes {.inject.}: uint32) =
-    body
-
-template onDone*(this: Zwp_tablet_pad_group_v2; body) =
-  ## This event is sent immediately to signal the end of the initial
-  ## burst of descriptive events. A client may consider the static
-  ## description of the tablet to be complete and finalize initialization
-  ## of the tablet group.
-  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
-    body
-
-template onMode_switch*(this: Zwp_tablet_pad_group_v2; body) =
-  ## Notification that the mode was switched.
-  ## 
-  ## A mode applies to all buttons, rings and strips in a group
-  ## simultaneously, but a client is not required to assign different actions
-  ## for each mode. For example, a client may have mode-specific button
-  ## mappings but map the ring to vertical scrolling in all modes. Mode
-  ## indices start at 0.
-  ## 
-  ## Switching modes is compositor-dependent. The compositor may provide
-  ## visual cues to the client about the mode, e.g. by toggling LEDs on
-  ## the tablet device. Mode-switching may be software-controlled or
-  ## controlled by one or more physical buttons. For example, on a Wacom
-  ## Intuos Pro, the button inside the ring may be assigned to switch
-  ## between modes.
-  ## 
-  ## The compositor will also send this event after wp_tablet_pad.enter on
-  ## each group in order to notify of the current mode. Groups that only
-  ## feature one mode will use mode=0 when emitting this event.
-  ## 
-  ## If a button action in the new mode differs from the action in the
-  ## previous mode, the client should immediately issue a
-  ## wp_tablet_pad.set_feedback request for each changed button.
-  ## 
-  ## If a ring or strip action in the new mode differs from the action
-  ## in the previous mode, the client should immediately issue a
-  ## wp_tablet_ring.set_feedback or wp_tablet_strip.set_feedback request
-  ## for each changed ring or strip.
-  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).mode_switch = proc (
-      time {.inject.}: uint32; serial {.inject.}: uint32; mode {.inject.}: uint32) =
-    body
-
-template onGroup*(this: Zwp_tablet_pad_v2; body) =
-  ## Sent on wp_tablet_pad initialization to announce available groups.
-  ## One event is sent for each pad group available.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_pad.done event. At least one group will be announced.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).group = proc (
-      pad_group {.inject.}: Zwp_tablet_pad_group_v2) =
-    body
-
-template onPath*(this: Zwp_tablet_pad_v2; body) =
-  ## A system-specific device path that indicates which device is behind
-  ## this wp_tablet_pad. This information may be used to gather additional
-  ## information about the device, e.g. through libwacom.
-  ## 
-  ## The format of the path is unspecified, it may be a device node, a
-  ## sysfs path, or some other identifier. It is up to the client to
-  ## identify the string provided.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_pad.done event.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).path = proc (
-      path {.inject.}: cstring) =
-    body
-
-template onButtons*(this: Zwp_tablet_pad_v2; body) =
-  ## Sent on wp_tablet_pad initialization to announce the available
-  ## buttons.
-  ## 
-  ## This event is sent in the initial burst of events before the
-  ## wp_tablet_pad.done event. This event is only sent when at least one
-  ## button is available.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).buttons = proc (
-      buttons {.inject.}: uint32) =
-    body
-
-template onDone*(this: Zwp_tablet_pad_v2; body) =
-  ## This event signals the end of the initial burst of descriptive
-  ## events. A client may consider the static description of the pad to
-  ## be complete and finalize initialization of the pad.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
-    body
-
-template onButton*(this: Zwp_tablet_pad_v2; body) =
-  ## Sent whenever the physical state of a button changes.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).button = proc (
-      time {.inject.}: uint32; button {.inject.}: uint32;
-      state {.inject.}: `Zwp_tablet_pad_v2 / Button_state`) =
-    body
-
-template onEnter*(this: Zwp_tablet_pad_v2; body) =
-  ## Notification that this pad is focused on the specified surface.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).enter = proc (
-      serial {.inject.}: uint32; tablet {.inject.}: Zwp_tablet_v2;
-      surface {.inject.}: Wl_surface) =
-    body
-
-template onLeave*(this: Zwp_tablet_pad_v2; body) =
-  ## Notification that this pad is no longer focused on the specified
-  ## surface.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).leave = proc (
-      serial {.inject.}: uint32; surface {.inject.}: Wl_surface) =
-    body
-
-template onRemoved*(this: Zwp_tablet_pad_v2; body) =
-  ## Sent when the pad has been removed from the system. When a tablet
-  ## is removed its pad(s) will be removed too.
-  ## 
-  ## When this event is received, the client must destroy all rings, strips
-  ## and groups that were offered by this pad, and issue wp_tablet_pad.destroy
-  ## the pad itself.
-  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).removed = proc () =
-    body
-
-template onAuto_hidden_panel_hidden*(this: Org_kde_plasma_surface; body) =
-  ## An auto-hiding panel got hidden by the compositor.
-  cast[ptr `Org_kde_plasma_surface / Callbacks`](this.proxy.raw.impl).auto_hidden_panel_hidden = proc () =
-    body
-
-template onAuto_hidden_panel_shown*(this: Org_kde_plasma_surface; body) =
-  ## An auto-hiding panel got shown by the compositor.
-  cast[ptr `Org_kde_plasma_surface / Callbacks`](this.proxy.raw.impl).auto_hidden_panel_shown = proc () =
+template onClosed*(this: Zwlr_layer_surface_v1; body) =
+  ## The closed event is sent by the compositor when the surface will no
+  ## longer be shown. The output may have been destroyed or the user may
+  ## have asked for it to be removed. Further changes to the surface will be
+  ## ignored. The client should destroy the resource after receiving this
+  ## event, and create a new surface if they so choose.
+  cast[ptr `Zwlr_layer_surface_v1 / Callbacks`](this.proxy.raw.impl).closed = proc () =
     body
 
 template onPing*(this: Xdg_wm_base; body) =
@@ -5402,6 +4994,16 @@ template onRepositioned*(this: Xdg_popup; body) =
   ## effect. See xdg_surface.ack_configure for details.
   cast[ptr `Xdg_popup / Callbacks`](this.proxy.raw.impl).repositioned = proc (
       token {.inject.}: uint32) =
+    body
+
+template onAuto_hidden_panel_hidden*(this: Org_kde_plasma_surface; body) =
+  ## An auto-hiding panel got hidden by the compositor.
+  cast[ptr `Org_kde_plasma_surface / Callbacks`](this.proxy.raw.impl).auto_hidden_panel_hidden = proc () =
+    body
+
+template onAuto_hidden_panel_shown*(this: Org_kde_plasma_surface; body) =
+  ## An auto-hiding panel got shown by the compositor.
+  cast[ptr `Org_kde_plasma_surface / Callbacks`](this.proxy.raw.impl).auto_hidden_panel_shown = proc () =
     body
 
 template onError*(this: Wl_display; body) =
@@ -6446,6 +6048,626 @@ template onDescription*(this: Wl_output; body) =
       description {.inject.}: cstring) =
     body
 
+template onTablet_added*(this: Zwp_tablet_seat_v2; body) =
+  ## This event is sent whenever a new tablet becomes available on this
+  ## seat. This event only provides the object id of the tablet, any
+  ## static information about the tablet (device name, vid/pid, etc.) is
+  ## sent through the wp_tablet interface.
+  cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](this.proxy.raw.impl).tablet_added = proc (
+      id {.inject.}: Zwp_tablet_v2) =
+    body
+
+template onTool_added*(this: Zwp_tablet_seat_v2; body) =
+  ## This event is sent whenever a tool that has not previously been used
+  ## with a tablet comes into use. This event only provides the object id
+  ## of the tool; any static information about the tool (capabilities,
+  ## type, etc.) is sent through the wp_tablet_tool interface.
+  cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](this.proxy.raw.impl).tool_added = proc (
+      id {.inject.}: Zwp_tablet_tool_v2) =
+    body
+
+template onPad_added*(this: Zwp_tablet_seat_v2; body) =
+  ## This event is sent whenever a new pad is known to the system. Typically,
+  ## pads are physically attached to tablets and a pad_added event is
+  ## sent immediately after the wp_tablet_seat.tablet_added.
+  ## However, some standalone pad devices logically attach to tablets at
+  ## runtime, and the client must wait for wp_tablet_pad.enter to know
+  ## the tablet a pad is attached to.
+  ## 
+  ## This event only provides the object id of the pad. All further
+  ## features (buttons, strips, rings) are sent through the wp_tablet_pad
+  ## interface.
+  cast[ptr `Zwp_tablet_seat_v2 / Callbacks`](this.proxy.raw.impl).pad_added = proc (
+      id {.inject.}: Zwp_tablet_pad_v2) =
+    body
+
+template onType*(this: Zwp_tablet_tool_v2; body) =
+  ## The tool type is the high-level type of the tool and usually decides
+  ## the interaction expected from this tool.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_tool.done event.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).`type` = proc (
+      tool_type {.inject.}: `Zwp_tablet_tool_v2 / Type`) =
+    body
+
+template onHardware_serial*(this: Zwp_tablet_tool_v2; body) =
+  ## If the physical tool can be identified by a unique 64-bit serial
+  ## number, this event notifies the client of this serial number.
+  ## 
+  ## If multiple tablets are available in the same seat and the tool is
+  ## uniquely identifiable by the serial number, that tool may move
+  ## between tablets.
+  ## 
+  ## Otherwise, if the tool has no serial number and this event is
+  ## missing, the tool is tied to the tablet it first comes into
+  ## proximity with. Even if the physical tool is used on multiple
+  ## tablets, separate wp_tablet_tool objects will be created, one per
+  ## tablet.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_tool.done event.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).hardware_serial = proc (
+      hardware_serial_hi {.inject.}: uint32;
+      hardware_serial_lo {.inject.}: uint32) =
+    body
+
+template onHardware_id_wacom*(this: Zwp_tablet_tool_v2; body) =
+  ## This event notifies the client of a hardware id available on this tool.
+  ## 
+  ## The hardware id is a device-specific 64-bit id that provides extra
+  ## information about the tool in use, beyond the wl_tool.type
+  ## enumeration. The format of the id is specific to tablets made by
+  ## Wacom Inc. For example, the hardware id of a Wacom Grip
+  ## Pen (a stylus) is 0x802.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_tool.done event.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).hardware_id_wacom = proc (
+      hardware_id_hi {.inject.}: uint32; hardware_id_lo {.inject.}: uint32) =
+    body
+
+template onCapability*(this: Zwp_tablet_tool_v2; body) =
+  ## This event notifies the client of any capabilities of this tool,
+  ## beyond the main set of x/y axes and tip up/down detection.
+  ## 
+  ## One event is sent for each extra capability available on this tool.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_tool.done event.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).capability = proc (
+      capability {.inject.}: `Zwp_tablet_tool_v2 / Capability`) =
+    body
+
+template onDone*(this: Zwp_tablet_tool_v2; body) =
+  ## This event signals the end of the initial burst of descriptive
+  ## events. A client may consider the static description of the tool to
+  ## be complete and finalize initialization of the tool.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
+    body
+
+template onRemoved*(this: Zwp_tablet_tool_v2; body) =
+  ## This event is sent when the tool is removed from the system and will
+  ## send no further events. Should the physical tool come back into
+  ## proximity later, a new wp_tablet_tool object will be created.
+  ## 
+  ## It is compositor-dependent when a tool is removed. A compositor may
+  ## remove a tool on proximity out, tablet removal or any other reason.
+  ## A compositor may also keep a tool alive until shutdown.
+  ## 
+  ## If the tool is currently in proximity, a proximity_out event will be
+  ## sent before the removed event. See wp_tablet_tool.proximity_out for
+  ## the handling of any buttons logically down.
+  ## 
+  ## When this event is received, the client must wp_tablet_tool.destroy
+  ## the object.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).removed = proc () =
+    body
+
+template onProximity_in*(this: Zwp_tablet_tool_v2; body) =
+  ## Notification that this tool is focused on a certain surface.
+  ## 
+  ## This event can be received when the tool has moved from one surface to
+  ## another, or when the tool has come back into proximity above the
+  ## surface.
+  ## 
+  ## If any button is logically down when the tool comes into proximity,
+  ## the respective button event is sent after the proximity_in event but
+  ## within the same frame as the proximity_in event.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).proximity_in = proc (
+      serial {.inject.}: uint32; tablet {.inject.}: Zwp_tablet_v2;
+      surface {.inject.}: Wl_surface) =
+    body
+
+template onProximity_out*(this: Zwp_tablet_tool_v2; body) =
+  ## Notification that this tool has either left proximity, or is no
+  ## longer focused on a certain surface.
+  ## 
+  ## When the tablet tool leaves proximity of the tablet, button release
+  ## events are sent for each button that was held down at the time of
+  ## leaving proximity. These events are sent before the proximity_out
+  ## event but within the same wp_tablet.frame.
+  ## 
+  ## If the tool stays within proximity of the tablet, but the focus
+  ## changes from one surface to another, a button release event may not
+  ## be sent until the button is actually released or the tool leaves the
+  ## proximity of the tablet.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).proximity_out = proc () =
+    body
+
+template onDown*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever the tablet tool comes in contact with the surface of the
+  ## tablet.
+  ## 
+  ## If the tool is already in contact with the tablet when entering the
+  ## input region, the client owning said region will receive a
+  ## wp_tablet.proximity_in event, followed by a wp_tablet.down
+  ## event and a wp_tablet.frame event.
+  ## 
+  ## Note that this event describes logical contact, not physical
+  ## contact. On some devices, a compositor may not consider a tool in
+  ## logical contact until a minimum physical pressure threshold is
+  ## exceeded.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).down = proc (
+      serial {.inject.}: uint32) =
+    body
+
+template onUp*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever the tablet tool stops making contact with the surface of
+  ## the tablet, or when the tablet tool moves out of the input region
+  ## and the compositor grab (if any) is dismissed.
+  ## 
+  ## If the tablet tool moves out of the input region while in contact
+  ## with the surface of the tablet and the compositor does not have an
+  ## ongoing grab on the surface, the client owning said region will
+  ## receive a wp_tablet.up event, followed by a wp_tablet.proximity_out
+  ## event and a wp_tablet.frame event. If the compositor has an ongoing
+  ## grab on this device, this event sequence is sent whenever the grab
+  ## is dismissed in the future.
+  ## 
+  ## Note that this event describes logical contact, not physical
+  ## contact. On some devices, a compositor may not consider a tool out
+  ## of logical contact until physical pressure falls below a specific
+  ## threshold.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).up = proc () =
+    body
+
+template onMotion*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever a tablet tool moves.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).motion = proc (
+      x {.inject.}: float32; y {.inject.}: float32) =
+    body
+
+template onPressure*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever the pressure axis on a tool changes. The value of this
+  ## event is normalized to a value between 0 and 65535.
+  ## 
+  ## Note that pressure may be nonzero even when a tool is not in logical
+  ## contact. See the down and up events for more details.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).pressure = proc (
+      pressure {.inject.}: uint32) =
+    body
+
+template onDistance*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever the distance axis on a tool changes. The value of this
+  ## event is normalized to a value between 0 and 65535.
+  ## 
+  ## Note that distance may be nonzero even when a tool is not in logical
+  ## contact. See the down and up events for more details.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).distance = proc (
+      distance {.inject.}: uint32) =
+    body
+
+template onTilt*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever one or both of the tilt axes on a tool change. Each tilt
+  ## value is in degrees, relative to the z-axis of the tablet.
+  ## The angle is positive when the top of a tool tilts along the
+  ## positive x or y axis.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).tilt = proc (
+      tilt_x {.inject.}: float32; tilt_y {.inject.}: float32) =
+    body
+
+template onRotation*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever the z-rotation axis on the tool changes. The
+  ## rotation value is in degrees clockwise from the tool's
+  ## logical neutral position.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).rotation = proc (
+      degrees {.inject.}: float32) =
+    body
+
+template onSlider*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever the slider position on the tool changes. The
+  ## value is normalized between -65535 and 65535, with 0 as the logical
+  ## neutral position of the slider.
+  ## 
+  ## The slider is available on e.g. the Wacom Airbrush tool.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).slider = proc (
+      position {.inject.}: int32) =
+    body
+
+template onWheel*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever the wheel on the tool emits an event. This event
+  ## contains two values for the same axis change. The degrees value is
+  ## in the same orientation as the wl_pointer.vertical_scroll axis. The
+  ## clicks value is in discrete logical clicks of the mouse wheel. This
+  ## value may be zero if the movement of the wheel was less
+  ## than one logical click.
+  ## 
+  ## Clients should choose either value and avoid mixing degrees and
+  ## clicks. The compositor may accumulate values smaller than a logical
+  ## click and emulate click events when a certain threshold is met.
+  ## Thus, wl_tablet_tool.wheel events with non-zero clicks values may
+  ## have different degrees values.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).wheel = proc (
+      degrees {.inject.}: float32; clicks {.inject.}: int32) =
+    body
+
+template onButton*(this: Zwp_tablet_tool_v2; body) =
+  ## Sent whenever a button on the tool is pressed or released.
+  ## 
+  ## If a button is held down when the tool moves in or out of proximity,
+  ## button events are generated by the compositor. See
+  ## wp_tablet_tool.proximity_in and wp_tablet_tool.proximity_out for
+  ## details.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).button = proc (
+      serial {.inject.}: uint32; button {.inject.}: uint32;
+      state {.inject.}: `Zwp_tablet_tool_v2 / Button_state`) =
+    body
+
+template onFrame*(this: Zwp_tablet_tool_v2; body) =
+  ## Marks the end of a series of axis and/or button updates from the
+  ## tablet. The Wayland protocol requires axis updates to be sent
+  ## sequentially, however all events within a frame should be considered
+  ## one hardware event.
+  cast[ptr `Zwp_tablet_tool_v2 / Callbacks`](this.proxy.raw.impl).frame = proc (
+      time {.inject.}: uint32) =
+    body
+
+template onName*(this: Zwp_tablet_v2; body) =
+  ## A descriptive name for the tablet device.
+  ## 
+  ## If the device has no descriptive name, this event is not sent.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet.done event.
+  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).name = proc (
+      name {.inject.}: cstring) =
+    body
+
+template onId*(this: Zwp_tablet_v2; body) =
+  ## The USB vendor and product IDs for the tablet device.
+  ## 
+  ## If the device has no USB vendor/product ID, this event is not sent.
+  ## This can happen for virtual devices or non-USB devices, for instance.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet.done event.
+  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).id = proc (
+      vid {.inject.}: uint32; pid {.inject.}: uint32) =
+    body
+
+template onPath*(this: Zwp_tablet_v2; body) =
+  ## A system-specific device path that indicates which device is behind
+  ## this wp_tablet. This information may be used to gather additional
+  ## information about the device, e.g. through libwacom.
+  ## 
+  ## A device may have more than one device path. If so, multiple
+  ## wp_tablet.path events are sent. A device may be emulated and not
+  ## have a device path, and in that case this event will not be sent.
+  ## 
+  ## The format of the path is unspecified, it may be a device node, a
+  ## sysfs path, or some other identifier. It is up to the client to
+  ## identify the string provided.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet.done event.
+  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).path = proc (
+      path {.inject.}: cstring) =
+    body
+
+template onDone*(this: Zwp_tablet_v2; body) =
+  ## This event is sent immediately to signal the end of the initial
+  ## burst of descriptive events. A client may consider the static
+  ## description of the tablet to be complete and finalize initialization
+  ## of the tablet.
+  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
+    body
+
+template onRemoved*(this: Zwp_tablet_v2; body) =
+  ## Sent when the tablet has been removed from the system. When a tablet
+  ## is removed, some tools may be removed.
+  ## 
+  ## When this event is received, the client must wp_tablet.destroy
+  ## the object.
+  cast[ptr `Zwp_tablet_v2 / Callbacks`](this.proxy.raw.impl).removed = proc () =
+    body
+
+template onSource*(this: Zwp_tablet_pad_ring_v2; body) =
+  ## Source information for ring events.
+  ## 
+  ## This event does not occur on its own. It is sent before a
+  ## wp_tablet_pad_ring.frame event and carries the source information
+  ## for all events within that frame.
+  ## 
+  ## The source specifies how this event was generated. If the source is
+  ## wp_tablet_pad_ring.source.finger, a wp_tablet_pad_ring.stop event
+  ## will be sent when the user lifts the finger off the device.
+  ## 
+  ## This event is optional. If the source is unknown for an interaction,
+  ## no event is sent.
+  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).source = proc (
+      source {.inject.}: `Zwp_tablet_pad_ring_v2 / Source`) =
+    body
+
+template onAngle*(this: Zwp_tablet_pad_ring_v2; body) =
+  ## Sent whenever the angle on a ring changes.
+  ## 
+  ## The angle is provided in degrees clockwise from the logical
+  ## north of the ring in the pad's current rotation.
+  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).angle = proc (
+      degrees {.inject.}: float32) =
+    body
+
+template onStop*(this: Zwp_tablet_pad_ring_v2; body) =
+  ## Stop notification for ring events.
+  ## 
+  ## For some wp_tablet_pad_ring.source types, a wp_tablet_pad_ring.stop
+  ## event is sent to notify a client that the interaction with the ring
+  ## has terminated. This enables the client to implement kinetic scrolling.
+  ## See the wp_tablet_pad_ring.source documentation for information on
+  ## when this event may be generated.
+  ## 
+  ## Any wp_tablet_pad_ring.angle events with the same source after this
+  ## event should be considered as the start of a new interaction.
+  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).stop = proc () =
+    body
+
+template onFrame*(this: Zwp_tablet_pad_ring_v2; body) =
+  ## Indicates the end of a set of ring events that logically belong
+  ## together. A client is expected to accumulate the data in all events
+  ## within the frame before proceeding.
+  ## 
+  ## All wp_tablet_pad_ring events before a wp_tablet_pad_ring.frame event belong
+  ## logically together. For example, on termination of a finger interaction
+  ## on a ring the compositor will send a wp_tablet_pad_ring.source event,
+  ## a wp_tablet_pad_ring.stop event and a wp_tablet_pad_ring.frame event.
+  ## 
+  ## A wp_tablet_pad_ring.frame event is sent for every logical event
+  ## group, even if the group only contains a single wp_tablet_pad_ring
+  ## event. Specifically, a client may get a sequence: angle, frame,
+  ## angle, frame, etc.
+  cast[ptr `Zwp_tablet_pad_ring_v2 / Callbacks`](this.proxy.raw.impl).frame = proc (
+      time {.inject.}: uint32) =
+    body
+
+template onSource*(this: Zwp_tablet_pad_strip_v2; body) =
+  ## Source information for strip events.
+  ## 
+  ## This event does not occur on its own. It is sent before a
+  ## wp_tablet_pad_strip.frame event and carries the source information
+  ## for all events within that frame.
+  ## 
+  ## The source specifies how this event was generated. If the source is
+  ## wp_tablet_pad_strip.source.finger, a wp_tablet_pad_strip.stop event
+  ## will be sent when the user lifts their finger off the device.
+  ## 
+  ## This event is optional. If the source is unknown for an interaction,
+  ## no event is sent.
+  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).source = proc (
+      source {.inject.}: `Zwp_tablet_pad_strip_v2 / Source`) =
+    body
+
+template onPosition*(this: Zwp_tablet_pad_strip_v2; body) =
+  ## Sent whenever the position on a strip changes.
+  ## 
+  ## The position is normalized to a range of [0, 65535], the 0-value
+  ## represents the top-most and/or left-most position of the strip in
+  ## the pad's current rotation.
+  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).position = proc (
+      position {.inject.}: uint32) =
+    body
+
+template onStop*(this: Zwp_tablet_pad_strip_v2; body) =
+  ## Stop notification for strip events.
+  ## 
+  ## For some wp_tablet_pad_strip.source types, a wp_tablet_pad_strip.stop
+  ## event is sent to notify a client that the interaction with the strip
+  ## has terminated. This enables the client to implement kinetic
+  ## scrolling. See the wp_tablet_pad_strip.source documentation for
+  ## information on when this event may be generated.
+  ## 
+  ## Any wp_tablet_pad_strip.position events with the same source after this
+  ## event should be considered as the start of a new interaction.
+  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).stop = proc () =
+    body
+
+template onFrame*(this: Zwp_tablet_pad_strip_v2; body) =
+  ## Indicates the end of a set of events that represent one logical
+  ## hardware strip event. A client is expected to accumulate the data
+  ## in all events within the frame before proceeding.
+  ## 
+  ## All wp_tablet_pad_strip events before a wp_tablet_pad_strip.frame event belong
+  ## logically together. For example, on termination of a finger interaction
+  ## on a strip the compositor will send a wp_tablet_pad_strip.source event,
+  ## a wp_tablet_pad_strip.stop event and a wp_tablet_pad_strip.frame
+  ## event.
+  ## 
+  ## A wp_tablet_pad_strip.frame event is sent for every logical event
+  ## group, even if the group only contains a single wp_tablet_pad_strip
+  ## event. Specifically, a client may get a sequence: position, frame,
+  ## position, frame, etc.
+  cast[ptr `Zwp_tablet_pad_strip_v2 / Callbacks`](this.proxy.raw.impl).frame = proc (
+      time {.inject.}: uint32) =
+    body
+
+template onButtons*(this: Zwp_tablet_pad_group_v2; body) =
+  ## Sent on wp_tablet_pad_group initialization to announce the available
+  ## buttons in the group. Button indices start at 0, a button may only be
+  ## in one group at a time.
+  ## 
+  ## This event is first sent in the initial burst of events before the
+  ## wp_tablet_pad_group.done event.
+  ## 
+  ## Some buttons are reserved by the compositor. These buttons may not be
+  ## assigned to any wp_tablet_pad_group. Compositors may broadcast this
+  ## event in the case of changes to the mapping of these reserved buttons.
+  ## If the compositor happens to reserve all buttons in a group, this event
+  ## will be sent with an empty array.
+  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).buttons = proc (
+      buttons {.inject.}: Wl_array) =
+    body
+
+template onRing*(this: Zwp_tablet_pad_group_v2; body) =
+  ## Sent on wp_tablet_pad_group initialization to announce available rings.
+  ## One event is sent for each ring available on this pad group.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_pad_group.done event.
+  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).ring = proc (
+      ring {.inject.}: Zwp_tablet_pad_ring_v2) =
+    body
+
+template onStrip*(this: Zwp_tablet_pad_group_v2; body) =
+  ## Sent on wp_tablet_pad initialization to announce available strips.
+  ## One event is sent for each strip available on this pad group.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_pad_group.done event.
+  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).strip = proc (
+      strip {.inject.}: Zwp_tablet_pad_strip_v2) =
+    body
+
+template onModes*(this: Zwp_tablet_pad_group_v2; body) =
+  ## Sent on wp_tablet_pad_group initialization to announce that the pad
+  ## group may switch between modes. A client may use a mode to store a
+  ## specific configuration for buttons, rings and strips and use the
+  ## wl_tablet_pad_group.mode_switch event to toggle between these
+  ## configurations. Mode indices start at 0.
+  ## 
+  ## Switching modes is compositor-dependent. See the
+  ## wp_tablet_pad_group.mode_switch event for more details.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_pad_group.done event. This event is only sent when more than
+  ## more than one mode is available.
+  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).modes = proc (
+      modes {.inject.}: uint32) =
+    body
+
+template onDone*(this: Zwp_tablet_pad_group_v2; body) =
+  ## This event is sent immediately to signal the end of the initial
+  ## burst of descriptive events. A client may consider the static
+  ## description of the tablet to be complete and finalize initialization
+  ## of the tablet group.
+  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
+    body
+
+template onMode_switch*(this: Zwp_tablet_pad_group_v2; body) =
+  ## Notification that the mode was switched.
+  ## 
+  ## A mode applies to all buttons, rings and strips in a group
+  ## simultaneously, but a client is not required to assign different actions
+  ## for each mode. For example, a client may have mode-specific button
+  ## mappings but map the ring to vertical scrolling in all modes. Mode
+  ## indices start at 0.
+  ## 
+  ## Switching modes is compositor-dependent. The compositor may provide
+  ## visual cues to the client about the mode, e.g. by toggling LEDs on
+  ## the tablet device. Mode-switching may be software-controlled or
+  ## controlled by one or more physical buttons. For example, on a Wacom
+  ## Intuos Pro, the button inside the ring may be assigned to switch
+  ## between modes.
+  ## 
+  ## The compositor will also send this event after wp_tablet_pad.enter on
+  ## each group in order to notify of the current mode. Groups that only
+  ## feature one mode will use mode=0 when emitting this event.
+  ## 
+  ## If a button action in the new mode differs from the action in the
+  ## previous mode, the client should immediately issue a
+  ## wp_tablet_pad.set_feedback request for each changed button.
+  ## 
+  ## If a ring or strip action in the new mode differs from the action
+  ## in the previous mode, the client should immediately issue a
+  ## wp_tablet_ring.set_feedback or wp_tablet_strip.set_feedback request
+  ## for each changed ring or strip.
+  cast[ptr `Zwp_tablet_pad_group_v2 / Callbacks`](this.proxy.raw.impl).mode_switch = proc (
+      time {.inject.}: uint32; serial {.inject.}: uint32; mode {.inject.}: uint32) =
+    body
+
+template onGroup*(this: Zwp_tablet_pad_v2; body) =
+  ## Sent on wp_tablet_pad initialization to announce available groups.
+  ## One event is sent for each pad group available.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_pad.done event. At least one group will be announced.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).group = proc (
+      pad_group {.inject.}: Zwp_tablet_pad_group_v2) =
+    body
+
+template onPath*(this: Zwp_tablet_pad_v2; body) =
+  ## A system-specific device path that indicates which device is behind
+  ## this wp_tablet_pad. This information may be used to gather additional
+  ## information about the device, e.g. through libwacom.
+  ## 
+  ## The format of the path is unspecified, it may be a device node, a
+  ## sysfs path, or some other identifier. It is up to the client to
+  ## identify the string provided.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_pad.done event.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).path = proc (
+      path {.inject.}: cstring) =
+    body
+
+template onButtons*(this: Zwp_tablet_pad_v2; body) =
+  ## Sent on wp_tablet_pad initialization to announce the available
+  ## buttons.
+  ## 
+  ## This event is sent in the initial burst of events before the
+  ## wp_tablet_pad.done event. This event is only sent when at least one
+  ## button is available.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).buttons = proc (
+      buttons {.inject.}: uint32) =
+    body
+
+template onDone*(this: Zwp_tablet_pad_v2; body) =
+  ## This event signals the end of the initial burst of descriptive
+  ## events. A client may consider the static description of the pad to
+  ## be complete and finalize initialization of the pad.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).done = proc () =
+    body
+
+template onButton*(this: Zwp_tablet_pad_v2; body) =
+  ## Sent whenever the physical state of a button changes.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).button = proc (
+      time {.inject.}: uint32; button {.inject.}: uint32;
+      state {.inject.}: `Zwp_tablet_pad_v2 / Button_state`) =
+    body
+
+template onEnter*(this: Zwp_tablet_pad_v2; body) =
+  ## Notification that this pad is focused on the specified surface.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).enter = proc (
+      serial {.inject.}: uint32; tablet {.inject.}: Zwp_tablet_v2;
+      surface {.inject.}: Wl_surface) =
+    body
+
+template onLeave*(this: Zwp_tablet_pad_v2; body) =
+  ## Notification that this pad is no longer focused on the specified
+  ## surface.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).leave = proc (
+      serial {.inject.}: uint32; surface {.inject.}: Wl_surface) =
+    body
+
+template onRemoved*(this: Zwp_tablet_pad_v2; body) =
+  ## Sent when the pad has been removed from the system. When a tablet
+  ## is removed its pad(s) will be removed too.
+  ## 
+  ## When this event is received, the client must destroy all rings, strips
+  ## and groups that were offered by this pad, and issue wp_tablet_pad.destroy
+  ## the pad itself.
+  cast[ptr `Zwp_tablet_pad_v2 / Callbacks`](this.proxy.raw.impl).removed = proc () =
+    body
+
 template onConfigure*(this: Zxdg_toplevel_decoration_v1; body) =
   ## The configure event configures the effective decoration mode. The
   ## configured state should not be applied immediately. Clients must send an
@@ -6458,41 +6680,11 @@ template onConfigure*(this: Zxdg_toplevel_decoration_v1; body) =
       mode {.inject.}: `Zxdg_toplevel_decoration_v1 / Mode`) =
     body
 
-template dispatch*(t: typedesc[Zwp_tablet_manager_v2]): untyped =
-  `Zwp_tablet_manager_v2 / dispatch`
+template dispatch*(t: typedesc[Zwlr_layer_shell_v1]): untyped =
+  `Zwlr_layer_shell_v1 / dispatch`
 
-template dispatch*(t: typedesc[Zwp_tablet_seat_v2]): untyped =
-  `Zwp_tablet_seat_v2 / dispatch`
-
-template dispatch*(t: typedesc[Zwp_tablet_tool_v2]): untyped =
-  `Zwp_tablet_tool_v2 / dispatch`
-
-template dispatch*(t: typedesc[Zwp_tablet_v2]): untyped =
-  `Zwp_tablet_v2 / dispatch`
-
-template dispatch*(t: typedesc[Zwp_tablet_pad_ring_v2]): untyped =
-  `Zwp_tablet_pad_ring_v2 / dispatch`
-
-template dispatch*(t: typedesc[Zwp_tablet_pad_strip_v2]): untyped =
-  `Zwp_tablet_pad_strip_v2 / dispatch`
-
-template dispatch*(t: typedesc[Zwp_tablet_pad_group_v2]): untyped =
-  `Zwp_tablet_pad_group_v2 / dispatch`
-
-template dispatch*(t: typedesc[Zwp_tablet_pad_v2]): untyped =
-  `Zwp_tablet_pad_v2 / dispatch`
-
-template dispatch*(t: typedesc[Org_kde_plasma_shell]): untyped =
-  `Org_kde_plasma_shell / dispatch`
-
-template dispatch*(t: typedesc[Org_kde_plasma_surface]): untyped =
-  `Org_kde_plasma_surface / dispatch`
-
-template dispatch*(t: typedesc[Wp_cursor_shape_manager_v1]): untyped =
-  `Wp_cursor_shape_manager_v1 / dispatch`
-
-template dispatch*(t: typedesc[Wp_cursor_shape_device_v1]): untyped =
-  `Wp_cursor_shape_device_v1 / dispatch`
+template dispatch*(t: typedesc[Zwlr_layer_surface_v1]): untyped =
+  `Zwlr_layer_surface_v1 / dispatch`
 
 template dispatch*(t: typedesc[Xdg_wm_base]): untyped =
   `Xdg_wm_base / dispatch`
@@ -6508,6 +6700,12 @@ template dispatch*(t: typedesc[Xdg_toplevel]): untyped =
 
 template dispatch*(t: typedesc[Xdg_popup]): untyped =
   `Xdg_popup / dispatch`
+
+template dispatch*(t: typedesc[Org_kde_plasma_shell]): untyped =
+  `Org_kde_plasma_shell / dispatch`
+
+template dispatch*(t: typedesc[Org_kde_plasma_surface]): untyped =
+  `Org_kde_plasma_surface / dispatch`
 
 template dispatch*(t: typedesc[Wl_display]): untyped =
   `Wl_display / dispatch`
@@ -6575,47 +6773,47 @@ template dispatch*(t: typedesc[Wl_subcompositor]): untyped =
 template dispatch*(t: typedesc[Wl_subsurface]): untyped =
   `Wl_subsurface / dispatch`
 
+template dispatch*(t: typedesc[Wp_cursor_shape_manager_v1]): untyped =
+  `Wp_cursor_shape_manager_v1 / dispatch`
+
+template dispatch*(t: typedesc[Wp_cursor_shape_device_v1]): untyped =
+  `Wp_cursor_shape_device_v1 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_manager_v2]): untyped =
+  `Zwp_tablet_manager_v2 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_seat_v2]): untyped =
+  `Zwp_tablet_seat_v2 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_tool_v2]): untyped =
+  `Zwp_tablet_tool_v2 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_v2]): untyped =
+  `Zwp_tablet_v2 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_pad_ring_v2]): untyped =
+  `Zwp_tablet_pad_ring_v2 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_pad_strip_v2]): untyped =
+  `Zwp_tablet_pad_strip_v2 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_pad_group_v2]): untyped =
+  `Zwp_tablet_pad_group_v2 / dispatch`
+
+template dispatch*(t: typedesc[Zwp_tablet_pad_v2]): untyped =
+  `Zwp_tablet_pad_v2 / dispatch`
+
 template dispatch*(t: typedesc[Zxdg_decoration_manager_v1]): untyped =
   `Zxdg_decoration_manager_v1 / dispatch`
 
 template dispatch*(t: typedesc[Zxdg_toplevel_decoration_v1]): untyped =
   `Zxdg_toplevel_decoration_v1 / dispatch`
 
-template Callbacks*(t: typedesc[Zwp_tablet_manager_v2]): untyped =
-  `Zwp_tablet_manager_v2 / Callbacks`
+template Callbacks*(t: typedesc[Zwlr_layer_shell_v1]): untyped =
+  `Zwlr_layer_shell_v1 / Callbacks`
 
-template Callbacks*(t: typedesc[Zwp_tablet_seat_v2]): untyped =
-  `Zwp_tablet_seat_v2 / Callbacks`
-
-template Callbacks*(t: typedesc[Zwp_tablet_tool_v2]): untyped =
-  `Zwp_tablet_tool_v2 / Callbacks`
-
-template Callbacks*(t: typedesc[Zwp_tablet_v2]): untyped =
-  `Zwp_tablet_v2 / Callbacks`
-
-template Callbacks*(t: typedesc[Zwp_tablet_pad_ring_v2]): untyped =
-  `Zwp_tablet_pad_ring_v2 / Callbacks`
-
-template Callbacks*(t: typedesc[Zwp_tablet_pad_strip_v2]): untyped =
-  `Zwp_tablet_pad_strip_v2 / Callbacks`
-
-template Callbacks*(t: typedesc[Zwp_tablet_pad_group_v2]): untyped =
-  `Zwp_tablet_pad_group_v2 / Callbacks`
-
-template Callbacks*(t: typedesc[Zwp_tablet_pad_v2]): untyped =
-  `Zwp_tablet_pad_v2 / Callbacks`
-
-template Callbacks*(t: typedesc[Org_kde_plasma_shell]): untyped =
-  `Org_kde_plasma_shell / Callbacks`
-
-template Callbacks*(t: typedesc[Org_kde_plasma_surface]): untyped =
-  `Org_kde_plasma_surface / Callbacks`
-
-template Callbacks*(t: typedesc[Wp_cursor_shape_manager_v1]): untyped =
-  `Wp_cursor_shape_manager_v1 / Callbacks`
-
-template Callbacks*(t: typedesc[Wp_cursor_shape_device_v1]): untyped =
-  `Wp_cursor_shape_device_v1 / Callbacks`
+template Callbacks*(t: typedesc[Zwlr_layer_surface_v1]): untyped =
+  `Zwlr_layer_surface_v1 / Callbacks`
 
 template Callbacks*(t: typedesc[Xdg_wm_base]): untyped =
   `Xdg_wm_base / Callbacks`
@@ -6631,6 +6829,12 @@ template Callbacks*(t: typedesc[Xdg_toplevel]): untyped =
 
 template Callbacks*(t: typedesc[Xdg_popup]): untyped =
   `Xdg_popup / Callbacks`
+
+template Callbacks*(t: typedesc[Org_kde_plasma_shell]): untyped =
+  `Org_kde_plasma_shell / Callbacks`
+
+template Callbacks*(t: typedesc[Org_kde_plasma_surface]): untyped =
+  `Org_kde_plasma_surface / Callbacks`
 
 template Callbacks*(t: typedesc[Wl_display]): untyped =
   `Wl_display / Callbacks`
@@ -6697,6 +6901,36 @@ template Callbacks*(t: typedesc[Wl_subcompositor]): untyped =
 
 template Callbacks*(t: typedesc[Wl_subsurface]): untyped =
   `Wl_subsurface / Callbacks`
+
+template Callbacks*(t: typedesc[Wp_cursor_shape_manager_v1]): untyped =
+  `Wp_cursor_shape_manager_v1 / Callbacks`
+
+template Callbacks*(t: typedesc[Wp_cursor_shape_device_v1]): untyped =
+  `Wp_cursor_shape_device_v1 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_manager_v2]): untyped =
+  `Zwp_tablet_manager_v2 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_seat_v2]): untyped =
+  `Zwp_tablet_seat_v2 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_tool_v2]): untyped =
+  `Zwp_tablet_tool_v2 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_v2]): untyped =
+  `Zwp_tablet_v2 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_pad_ring_v2]): untyped =
+  `Zwp_tablet_pad_ring_v2 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_pad_strip_v2]): untyped =
+  `Zwp_tablet_pad_strip_v2 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_pad_group_v2]): untyped =
+  `Zwp_tablet_pad_group_v2 / Callbacks`
+
+template Callbacks*(t: typedesc[Zwp_tablet_pad_v2]): untyped =
+  `Zwp_tablet_pad_v2 / Callbacks`
 
 template Callbacks*(t: typedesc[Zxdg_decoration_manager_v1]): untyped =
   `Zxdg_decoration_manager_v1 / Callbacks`

--- a/src/siwin/platforms/wayland/protocols/wlr-layer-shell-unstable-v1.xml
+++ b/src/siwin/platforms/wayland/protocols/wlr-layer-shell-unstable-v1.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_layer_shell_unstable_v1">
+  <copyright>
+    Copyright © 2017 Drew DeVault
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_layer_shell_v1" version="4">
+    <description summary="create surfaces that are layers of the desktop">
+      Clients can use this interface to assign the surface_layer role to
+      wl_surfaces. Such surfaces are assigned to a "layer" of the output and
+      rendered with a defined z-depth respective to each other. They may also be
+      anchored to the edges and corners of a screen and specify input handling
+      semantics. This interface should be suitable for the implementation of
+      many desktop shell components, and a broad number of other applications
+      that interact with the desktop.
+    </description>
+
+    <request name="get_layer_surface">
+      <description summary="create a layer_surface from a surface">
+        Create a layer surface for an existing surface. This assigns the role of
+        layer_surface, or raises a protocol error if another role is already
+        assigned.
+
+        Creating a layer surface from a wl_surface which has a buffer attached
+        or committed is a client error, and any attempts by a client to attach
+        or manipulate a buffer prior to the first layer_surface.configure call
+        must also be treated as errors.
+
+        After creating a layer_surface object and setting it up, the client
+        must perform an initial commit without any buffer attached.
+        The compositor will reply with a layer_surface.configure event.
+        The client must acknowledge it and is then allowed to attach a buffer
+        to map the surface.
+
+        You may pass NULL for output to allow the compositor to decide which
+        output to use. Generally this will be the one that the user most
+        recently interacted with.
+
+        Clients can specify a namespace that defines the purpose of the layer
+        surface.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_layer_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
+      <arg name="namespace" type="string" summary="namespace for the layer surface"/>
+    </request>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="wl_surface has another role"/>
+      <entry name="invalid_layer" value="1" summary="layer value is invalid"/>
+      <entry name="already_constructed" value="2" summary="wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <enum name="layer">
+      <description summary="available layers for surfaces">
+        These values indicate which layers a surface can be rendered in. They
+        are ordered by z depth, bottom-most first. Traditional shell surfaces
+        will typically be rendered between the bottom and top layers.
+        Fullscreen shell surfaces are typically rendered at the top layer.
+        Multiple surfaces can share a single layer, and ordering within a
+        single layer is undefined.
+      </description>
+
+      <entry name="background" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="top" value="2"/>
+      <entry name="overlay" value="3"/>
+    </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_layer_surface_v1" version="4">
+    <description summary="layer metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered as a layer of a stacked desktop-like
+      environment.
+
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
+
+      Attaching a null buffer to a layer surface unmaps it.
+
+      Unmapping a layer_surface means that the surface cannot be shown by the
+      compositor until it is explicitly mapped again. The layer_surface
+      returns to the state it had right after layer_shell.get_layer_surface.
+      The client can re-map the surface by performing a commit without any
+      buffer attached, waiting for a configure event and handling it as usual.
+    </description>
+
+    <request name="set_size">
+      <description summary="sets the size of the surface">
+        Sets the size of the surface in surface-local coordinates. The
+        compositor will display the surface centered with respect to its
+        anchors.
+
+        If you pass 0 for either value, the compositor will assign it and
+        inform you of the assignment in the configure event. You must set your
+        anchor to opposite edges in the dimensions you omit; not doing so is a
+        protocol error. Both values are 0 by default.
+
+        Size is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="set_anchor">
+      <description summary="configures the anchor point of the surface">
+        Requests that the compositor anchor the surface to the specified edges
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
+        'left'), then the anchor point will be the intersection of the edges
+        (e.g. the top left corner of the output); otherwise the anchor point
+        will be centered on that edge, or in the center if none is specified.
+
+        Anchor is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"/>
+    </request>
+
+    <request name="set_exclusive_zone">
+      <description summary="configures the exclusive geometry of this surface">
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
+        implementation-dependent - do not assume that this region will not
+        actually be occluded.
+
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
+
+        Surfaces that do not wish to have an exclusive zone may instead specify
+        how they should interact with surfaces that do. If set to zero, the
+        surface indicates that it would like to be moved to avoid occluding
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
+        surfaces, and the compositor should extend it all the way to the edges
+        it is anchored to.
+
+        For example, a panel might set its exclusive zone to 10, so that
+        maximized shell surfaces are not shown on top of it. A notification
+        might set its exclusive zone to 0, so that it is moved to avoid
+        occluding the panel, but shell surfaces are shown underneath it. A
+        wallpaper or lock screen might set their exclusive zone to -1, so that
+        they stretch below or over the panel.
+
+        The default value is 0.
+
+        Exclusive zone is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="zone" type="int"/>
+    </request>
+
+    <request name="set_margin">
+      <description summary="sets a margin from the anchor point">
+        Requests that the surface be placed some distance away from the anchor
+        point on the output, in surface-local coordinates. Setting this value
+        for edges you are not anchored to has no effect.
+
+        The exclusive zone includes the margin.
+
+        Margin is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="top" type="int"/>
+      <arg name="right" type="int"/>
+      <arg name="bottom" type="int"/>
+      <arg name="left" type="int"/>
+    </request>
+
+    <enum name="keyboard_interactivity">
+      <description summary="types of keyboard interaction possible for a layer shell surface">
+        Types of keyboard interaction possible for layer shell surfaces. The
+        rationale for this is twofold: (1) some applications are not interested
+        in keyboard events and not allowing them to be focused can improve the
+        desktop experience; (2) some applications will want to take exclusive
+        keyboard focus.
+      </description>
+
+      <entry name="none" value="0">
+        <description summary="no keyboard focus is possible">
+          This value indicates that this surface is not interested in keyboard
+          events and the compositor should never assign it the keyboard focus.
+
+          This is the default value, set for newly created layer shell surfaces.
+
+          This is useful for e.g. desktop widgets that display information or
+          only have interaction with non-keyboard input devices.
+        </description>
+      </entry>
+      <entry name="exclusive" value="1">
+        <description summary="request exclusive keyboard focus">
+          Request exclusive keyboard focus if this surface is above the shell surface layer.
+
+          For the top and overlay layers, the seat will always give
+          exclusive keyboard focus to the top-most layer which has keyboard
+          interactivity set to exclusive. If this layer contains multiple
+          surfaces with keyboard interactivity set to exclusive, the compositor
+          determines the one receiving keyboard events in an implementation-
+          defined manner. In this case, no guarantee is made when this surface
+          will receive keyboard focus (if ever).
+
+          For the bottom and background layers, the compositor is allowed to use
+          normal focus semantics.
+
+          This setting is mainly intended for applications that need to ensure
+          they receive all keyboard events, such as a lock screen or a password
+          prompt.
+        </description>
+      </entry>
+      <entry name="on_demand" value="2" since="4">
+        <description summary="request regular keyboard focus semantics">
+          This requests the compositor to allow this surface to be focused and
+          unfocused by the user in an implementation-defined manner. The user
+          should be able to unfocus this surface even regardless of the layer
+          it is on.
+
+          Typically, the compositor will want to use its normal mechanism to
+          manage keyboard focus between layer shell surfaces with this setting
+          and regular toplevels on the desktop layer (e.g. click to focus).
+          Nevertheless, it is possible for a compositor to require a special
+          interaction to focus or unfocus layer shell surfaces (e.g. requiring
+          a click even if focus follows the mouse normally, or providing a
+          keybinding to switch focus between layers).
+
+          This setting is mainly intended for desktop shell components (e.g.
+          panels) that allow keyboard interaction. Using this option can allow
+          implementing a desktop shell that can be fully usable without the
+          mouse.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="set_keyboard_interactivity">
+      <description summary="requests keyboard events">
+        Set how keyboard events are delivered to this surface. By default,
+        layer shell surfaces do not receive keyboard events; this request can
+        be used to change this.
+
+        This setting is inherited by child surfaces set by the get_popup
+        request.
+
+        Layer surfaces receive pointer, touch, and tablet events normally. If
+        you do not want to receive them, set the input region on your surface
+        to an empty region.
+
+        Keyboard interactivity is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="keyboard_interactivity" type="uint" enum="keyboard_interactivity"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign this layer_surface as an xdg_popup parent">
+        This assigns an xdg_popup's parent to this layer_surface.  This popup
+        should have been created via xdg_surface::get_popup with the parent set
+        to NULL, and this request must be invoked before committing the popup's
+        initial state.
+
+        See the documentation of xdg_popup for more details about what an
+        xdg_popup is and how it is used.
+      </description>
+      <arg name="popup" type="object" interface="xdg_popup"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the
+        surface in response to the configure event, then the client
+        must make an ack_configure request sometime before the commit
+        request, passing along the serial of the configure event.
+
+        If the client receives multiple configure events before it
+        can respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending
+        an ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing, but
+        only the last request sent before a commit indicates which configure
+        event the client really is responding to.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the layer_surface">
+        This request destroys the layer surface.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+        The configure event asks the client to resize its surface.
+
+        Clients should arrange their surface for the new states, and then send
+        an ack_configure request with the serial sent in this configure event at
+        some point before committing the new surface.
+
+        The client is free to dismiss all but the last configure event it
+        received.
+
+        The width and height arguments specify the size of the window in
+        surface-local coordinates.
+
+        The size is a hint, in the sense that the client is free to ignore it if
+        it doesn't resize, pick a smaller size (to satisfy aspect ratio or
+        resize in steps of NxM pixels). If the client picks a smaller size and
+        is anchored to two opposite anchors (e.g. 'top' and 'bottom'), the
+        surface will be centered on this axis.
+
+        If the width or height arguments are zero, it means the client should
+        decide its own window dimension.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+
+    <event name="closed">
+      <description summary="surface should be closed">
+        The closed event is sent by the compositor when the surface will no
+        longer be shown. The output may have been destroyed or the user may
+        have asked for it to be removed. Further changes to the surface will be
+        ignored. The client should destroy the resource after receiving this
+        event, and create a new surface if they so choose.
+      </description>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
+      <entry name="invalid_size" value="1" summary="size is invalid"/>
+      <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+      <entry name="invalid_keyboard_interactivity" value="3" summary="keyboard interactivity is invalid"/>
+    </enum>
+
+    <enum name="anchor" bitfield="true">
+      <entry name="top" value="1" summary="the top edge of the anchor rectangle"/>
+      <entry name="bottom" value="2" summary="the bottom edge of the anchor rectangle"/>
+      <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
+      <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
+    </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
+  </interface>
+</protocol>

--- a/src/siwin/platforms/wayland/window.nim
+++ b/src/siwin/platforms/wayland/window.nim
@@ -13,7 +13,10 @@ type
   ScreenWayland* = ref object of Screen
     id: cint
 
-
+  WindowWaylandKind* {.pure.} = enum
+    XdgSurface
+    LayerSurface
+  
   WindowWayland* = ref WindowWaylandObj
   WindowWaylandObj* = object of Window
     surface: Wl_surface
@@ -25,12 +28,18 @@ type
 
     plasmaSurface: Org_kde_plasma_surface
       # will be nil if compositor doesn't support this protocol
+    
+    layerShellSurface: Zwlr_layer_surface_v1
+      # will be nil if compositor doesn't support this protocol (eg. GNOME)
+    layer: Layer
+    namespace: string
 
     lastClickTime: Duration
     doubleClickHandled: bool
 
     lastMouseButtonEventSerial: uint32
     enterSerial: uint32
+    kind: WindowWaylandKind ## is this a normal window or is it a layer shell surface?
 
     lastKeyPressed: Key
     lastTextEntered: string
@@ -279,19 +288,26 @@ proc resize(window: WindowWayland, size: IVec2) =
     
   window.doResize size
   
-  if not window.m_resizable:
-    window.xdgToplevel.set_min_size(window.m_size.x, window.m_size.y)
-    window.xdgToplevel.set_max_size(window.m_size.x, window.m_size.y)
+  case window.kind
+  of WindowWaylandKind.XdgSurface:
+    if not window.m_resizable:
+      window.xdgToplevel.set_min_size(window.m_size.x, window.m_size.y)
+      window.xdgToplevel.set_max_size(window.m_size.x, window.m_size.y)
 
-  commit window.surface
+    commit window.surface
 
-  window.eventsHandler.pushEvent onResize, ResizeEvent(window: window, size: window.m_size)
-  redraw window
-
+    window.eventsHandler.pushEvent onResize, ResizeEvent(window: window, size: window.m_size)
+    redraw window
+  of WindowWaylandKind.LayerSurface:
+    echo window.m_size
+    window.layerShellSurface.set_size(window.m_size.x.uint32, window.m_size.y.uint32)
+    window.redraw()
 
 method `title=`*(window: WindowWayland, v: string) =
-  window.xdgToplevel.set_title(v)
-
+  case window.kind
+  of WindowWaylandKind.XdgSurface:
+    window.xdgToplevel.set_title(v)
+  else: discard
 
 proc setFrameless(window: WindowWayland, v: bool) =
   if serverDecorationManager != nil:
@@ -406,6 +422,17 @@ method `maximized=`*(window: WindowWayland, v: bool) =
     window: window, kind: StateBoolChangedEventKind.maximized, value: window.m_maximized
   )
 
+method setLayer*(window: WindowWayland, layer: Layer) =
+  let converted = `Zwlr_layer_shell_v1/Layer`(layer)
+
+  if window.layerShellSurface == nil:
+    raise newException(
+      ValueError, 
+      "Attempt to set surface layer when layer shell surface hasn't been initialized." &
+      "\nHint: Pass `kind` as `WindowWaylandKind.LayerSurface` when constructing this window."
+    )
+
+  window.layerShellSurface.set_layer(converted)
 
 proc releaseAllKeys(window: WindowWayland) =
   ## release all pressed keys
@@ -420,7 +447,8 @@ method `minimized=`*(window: WindowWayland, v: bool) =
   if not v:
     ## todo
   else:
-    window.xdgToplevel.set_minimized()
+    if window.kind == WindowWaylandKind.XdgSurface:
+      window.xdgToplevel.set_minimized()
 
 
 method `visible=`*(window: WindowWayland, v: bool) =
@@ -430,6 +458,7 @@ method `visible=`*(window: WindowWayland, v: bool) =
 
 
 method `resizable=`*(window: WindowWayland, v: bool) =
+  if window.kind != WindowWaylandKind.XdgSurface: return
   window.m_resizable = v
   let size = window.size
 
@@ -444,35 +473,35 @@ method `resizable=`*(window: WindowWayland, v: bool) =
 method `minSize=`*(window: WindowWayland, v: IVec2) =
   window.m_minSize = v
   if not window.m_resizable: return
-  window.xdgToplevel.set_min_size(v.x, v.y)
+  if window.kind == WindowWaylandKind.XdgSurface: window.xdgToplevel.set_min_size(v.x, v.y)
 
 
 method `maxSize=`*(window: WindowWayland, v: IVec2) =
   window.m_maxSize = v
   if not window.m_resizable: return
-  window.xdgToplevel.set_max_size(v.x, v.y)
 
+  if window.kind == WindowWaylandKind.XdgSurface: window.xdgToplevel.set_max_size(v.x, v.y)
 
 method startInteractiveMove*(window: WindowWayland, pos: Option[Vec2]) =
   expectExtension seat
-  window.xdgToplevel.move(seat, window.lastMouseButtonEventSerial)
-
+  if window.kind == WindowWaylandKind.XdgSurface: window.xdgToplevel.move(seat, window.lastMouseButtonEventSerial)
 
 method startInteractiveResize*(window: WindowWayland, edge: Edge, pos: Option[Vec2]) =
   expectExtension seat
-  window.xdgToplevel.resize(
-    seat, window.lastMouseButtonEventSerial,
-    case edge
-    of Edge.topLeft:     `Xdg_toplevel/Resize_edge`.top_left
-    of Edge.top:         `Xdg_toplevel/Resize_edge`.top
-    of Edge.topRight:    `Xdg_toplevel/Resize_edge`.top_right
-    of Edge.right:       `Xdg_toplevel/Resize_edge`.right
-    of Edge.bottomRight: `Xdg_toplevel/Resize_edge`.bottom_right
-    of Edge.bottom:      `Xdg_toplevel/Resize_edge`.bottom
-    of Edge.bottomLeft:  `Xdg_toplevel/Resize_edge`.bottom_left
-    of Edge.left:        `Xdg_toplevel/Resize_edge`.left
-  )
 
+  if window.kind == WindowWaylandKind.XdgSurface:
+    window.xdgToplevel.resize(
+      seat, window.lastMouseButtonEventSerial,
+      case edge
+      of Edge.topLeft:     `Xdg_toplevel/Resize_edge`.top_left
+      of Edge.top:         `Xdg_toplevel/Resize_edge`.top
+      of Edge.topRight:    `Xdg_toplevel/Resize_edge`.top_right
+      of Edge.right:       `Xdg_toplevel/Resize_edge`.right
+      of Edge.bottomRight: `Xdg_toplevel/Resize_edge`.bottom_right
+      of Edge.bottom:      `Xdg_toplevel/Resize_edge`.bottom
+      of Edge.bottomLeft:  `Xdg_toplevel/Resize_edge`.bottom_left
+      of Edge.left:        `Xdg_toplevel/Resize_edge`.left
+    )
 
 method showWindowMenu*(window: WindowWayland, pos: Option[Vec2]) =
   let pos = pos.get(window.mouse.pos).ivec2
@@ -685,7 +714,6 @@ proc initSeatEvents* =
     seat_keyboard.onRepeat_info:
       seat_keyboard_repeatSettings = (rate: rate, delay: delay)
 
-
 proc setupWindow(window: WindowWayland, fullscreen, frameless, transparent: bool, size: IVec2, class: string) =
   expectExtension compositor
   expectExtension xdgWmBase
@@ -695,54 +723,71 @@ proc setupWindow(window: WindowWayland, fullscreen, frameless, transparent: bool
   window.surface = compositor.create_surface
   associatedWindows[window.surface.proxy.raw.id] = window
 
-  window.xdgSurface = xdgWmBase.get_xdg_surface(window.surface)
-  window.xdgToplevel = window.xdgSurface.get_toplevel
+  case window.kind
+  of WindowWaylandKind.XdgSurface:
+    window.xdgSurface = xdgWmBase.get_xdg_surface(window.surface)
+    window.xdgToplevel = window.xdgSurface.get_toplevel
 
-  window.xdgSurface.onConfigure:
-    window.xdgSurface.ack_configure(serial)
-    commit window.surface
+    window.xdgSurface.onConfigure:
+      window.xdgSurface.ack_configure(serial)
+      commit window.surface
 
-  window.fullscreen = fullscreen
+    window.fullscreen = fullscreen
 
-  window.m_frameless = frameless
-  window.setFrameless(frameless)
+    window.m_frameless = frameless
+    window.setFrameless(frameless)
 
-  window.m_transparent = transparent
-  if not transparent:
-    let opaqueRegion = compositor.create_region
-    opaqueRegion.add(0, 0, size.x, size.y)
-    window.surface.set_opaque_region(opaqueRegion)
-    destroy opaqueRegion
+    window.m_transparent = transparent
+    if not transparent:
+      let opaqueRegion = compositor.create_region
+      opaqueRegion.add(0, 0, size.x, size.y)
+      window.surface.set_opaque_region(opaqueRegion)
+      destroy opaqueRegion
   
-  if class != "":
-    window.xdgToplevel.set_app_id(class)
+    if class != "":
+      window.xdgToplevel.set_app_id(class)
 
-  window.xdgToplevel.onClose:
-    window.m_closed = true
+    window.xdgToplevel.onClose:
+      window.m_closed = true
 
-  window.xdgToplevel.onConfigure:
-    window.resize(ivec2(width, height))
+    window.xdgToplevel.onConfigure:
+      window.resize(ivec2(width, height))
 
-    let states = states.toSeq(`XdgToplevel / State`)
+      let states = states.toSeq(`XdgToplevel / State`)
     
-    template checkState(state: `XdgToplevel / State`): bool = state in states
-    template handleState(k, n, m: untyped) =
-      if window.m != checkState(`XdgToplevel / State`.n):
-        window.m = checkState(`XdgToplevel / State`.n)
-        window.eventsHandler.pushEvent onStateBoolChanged, StateBoolChangedEvent(
-          window: window, kind: StateBoolChangedEventKind.k, value: window.m, isExternal: true
-        )
+      template checkState(state: `XdgToplevel / State`): bool = state in states
+      template handleState(k, n, m: untyped) =
+        if window.m != checkState(`XdgToplevel / State`.n):
+          window.m = checkState(`XdgToplevel / State`.n)
+          window.eventsHandler.pushEvent onStateBoolChanged, StateBoolChangedEvent(
+            window: window, kind: StateBoolChangedEventKind.k, value: window.m, isExternal: true
+          )
     
-    handleState maximized, maximized, m_maximized
-    handleState fullscreen, fullscreen, m_fullscreen
-    handleState focus, activated, m_focused
+      handleState maximized, maximized, m_maximized
+      handleState fullscreen, fullscreen, m_fullscreen
+      handleState focus, activated, m_focused
 
-    redraw window
+      redraw window
   
-  if plasmaShell != nil:
-    window.plasmaSurface = plasmaShell.get_surface(window.surface)
+    if plasmaShell != nil:
+      window.plasmaSurface = plasmaShell.get_surface(window.surface)
+  of LayerSurface:
+    window.layerShellSurface = layerShell.get_layer_surface(
+      window.surface,
+      Wl_output(proxy: Wl_proxy(raw: nil)),
+      `Zwlr_layer_shell_v1/Layer`(window.layer),
+      window.namespace.cstring
+    )
+    window.layerShellSurface.set_size(400, 400)
 
+    window.layerShellSurface.onConfigure:
+      window.layerShellSurface.ack_configure(serial)
+      window.resize(ivec2(width.int32, height.int32))
+      redraw window
 
+    window.layerShellSurface.onClosed:
+      window.m_closed = true
+      window.surface.destroy()
 
 proc initSoftwareRenderingWindow(
   window: WindowWaylandSoftwareRendering,
@@ -760,6 +805,79 @@ proc initSoftwareRenderingWindow(
   window.surface.attach(window.buffer.buffer, 0, 0)
   commit window.surface
 
+method setAnchor*(window: WindowWayland, edge: LayerEdge | array[2, LayerEdge], marginSize: int) {.base.} =
+  if window.layerShellSurface == nil:
+    raise newException(
+      ValueError,
+      "Attempt to set surface anchor when layer shell surface hasn't been initialized." &
+      "\nHint: Pass `kind` as `WindowWaylandKind.LayerSurface` when constructing this window."
+    )
+  
+  when edge is LayerEdge:
+    window.layerShellSurface.set_anchor(
+      case edge
+      of LayerEdge.Top:
+        `Zwlr_layer_surface_v1/Anchor`.top
+      of LayerEdge.Left:
+        `Zwlr_layer_surface_v1/Anchor`.left
+      of LayerEdge.Right:
+        `Zwlr_layer_surface_v1/Anchor`.right
+      of LayerEdge.Bottom:
+        `Zwlr_layer_surface_v1/Anchor`.bottom
+    )
+  else:
+    proc mixWith(l1: `Zwlr_layer_surface_v1/Anchor`): `Zwlr_layer_surface_v1/Anchor` =
+      `Zwlr_layer_surface_v1/Anchor`(case edge[1]
+      of LayerEdge.Top:
+        l1.uint or `Zwlr_layer_surface_v1/Anchor`.top.uint
+      of LayerEdge.Left:
+        l1.uint or `Zwlr_layer_surface_v1/Anchor`.left.uint
+      of LayerEdge.Right:
+        l1.uint or `Zwlr_layer_surface_v1/Anchor`.right.uint
+      of LayerEdge.Bottom:
+        l1.uint or `Zwlr_layer_surface_v1/Anchor`.bottom.uint)
+
+    window.layerShellSurface.set_anchor(
+      case edge[0]
+      of LayerEdge.Top:
+        mixWith `Zwlr_layer_surface_v1/Anchor`.top
+      of LayerEdge.Left:
+        mixWith `Zwlr_layer_surface_v1/Anchor`.left
+      of LayerEdge.Right:
+        mixWith `Zwlr_layer_surface_v1/Anchor`.right
+      of LayerEdge.Bottom:
+        mixWith `Zwlr_layer_surface_v1/Anchor`.bottom
+    )
+
+  window.redraw()
+
+method setKeyboardInteractivity*(window: WindowWayland, mode: LayerInteractivityMode) =
+  if window.layerShellSurface == nil:
+    raise newException(
+      ValueError, 
+      "Attempt to set keyboard interactivity when layer shell surface hasn't been initialized." &
+      "\nHint: Pass `kind` as `WindowWaylandKind.LayerSurface` when constructing this window."
+    )
+
+  window.layerShellSurface.set_keyboard_interactivity(
+    case mode
+    of LayerInteractivityMode.None:
+      `Zwlr_layer_surface_v1/Keyboard_interactivity`.none
+    of LayerInteractivityMode.Exclusive:
+      `Zwlr_layer_surface_v1/Keyboard_interactivity`.exclusive
+    of LayerInteractivityMode.OnDemand:
+      `Zwlr_layer_surface_v1/Keyboard_interactivity`.on_demand
+  )
+
+method setExclusiveZone*(window: WindowWayland, zone: int32) =
+  if window.layerShellSurface == nil:
+    raise newException(
+      ValueError, 
+      "Attempt to set keyboard interactivity when layer shell surface hasn't been initialized." &
+      "\nHint: Pass `kind` as `WindowWaylandKind.LayerSurface` when constructing this window."
+    )
+
+  window.layerShellSurface.set_exclusive_zone(zone)
 
 method firstStep*(window: WindowWayland, makeVisible = true) =
   if makeVisible:
@@ -771,7 +889,6 @@ method firstStep*(window: WindowWayland, makeVisible = true) =
   window.eventsHandler.pushEvent onResize, ResizeEvent(window: window, size: window.m_size, initial: true)
   window.lastTickTime = getTime()
   redraw window
-
 
 method step*(window: WindowWayland) =
   ## make window main loop step
@@ -786,6 +903,9 @@ method step*(window: WindowWayland) =
   closeIfNeeded()
   
   let eventCount = wl_display_roundtrip(globals.display)
+  if eventCount < 0:
+    raise newException(RoundtripFailed, "wl_display_roundtrip() returned " & $eventCount)
+
   closeIfNeeded()
   if eventCount == 0: sleep(1)
 
@@ -847,3 +967,5 @@ proc newSoftwareRenderingWindowWayland*(
   result.initSoftwareRenderingWindow(size, screen, fullscreen, frameless, transparent, (if class == "": title else: class))
   result.title = title
   if not resizable: result.resizable = false
+
+export Layer, LayerEdge, LayerInteractivityMode

--- a/src/siwin/platforms/wayland/window.nim
+++ b/src/siwin/platforms/wayland/window.nim
@@ -300,6 +300,7 @@ proc resize(window: WindowWayland, size: IVec2) =
     redraw window
   of WindowWaylandKind.LayerSurface:
     window.layerShellSurface.set_size(window.m_size.x.uint32, window.m_size.y.uint32)
+    window.surface.commit()
     window.redraw()
 
 method `title=`*(window: WindowWayland, v: string) =
@@ -778,6 +779,8 @@ proc setupWindow(window: WindowWayland, fullscreen, frameless, transparent: bool
       window.namespace.cstring
     )
     window.layerShellSurface.set_size(400, 400)
+    window.surface.commit()
+    window.redraw()
 
     window.layerShellSurface.onConfigure:
       window.layerShellSurface.ack_configure(serial)

--- a/src/siwin/platforms/wayland/window.nim
+++ b/src/siwin/platforms/wayland/window.nim
@@ -299,7 +299,6 @@ proc resize(window: WindowWayland, size: IVec2) =
     window.eventsHandler.pushEvent onResize, ResizeEvent(window: window, size: window.m_size)
     redraw window
   of WindowWaylandKind.LayerSurface:
-    echo window.m_size
     window.layerShellSurface.set_size(window.m_size.x.uint32, window.m_size.y.uint32)
     window.redraw()
 

--- a/src/siwin/platforms/wayland/windowOpengl.nim
+++ b/src/siwin/platforms/wayland/windowOpengl.nim
@@ -33,7 +33,6 @@ method release(window: WindowWaylandOpengl) =
 
   procCall window.WindowWayland.release()
 
-
 proc initOpenglWindow(
   window: WindowWaylandOpengl,
   size: IVec2, screen: ScreenWayland,
@@ -74,10 +73,16 @@ proc newOpenglWindowWayland*(
   frameless = false,
   transparent = false,
   vsync = true,
+  kind = WindowWaylandKind.XdgSurface,
+  layer = Layer.Overlay,
+  namespace = "siwin",
 
   class = "", # window class (used in x11), equals to title if not specified
 ): WindowWaylandOpengl =
   new result
+  result.kind = kind
+  result.namespace = namespace
+  result.layer = layer
   result.initOpenglWindow(size, screen, fullscreen, frameless, transparent, (if class == "": title else: class))
   result.title = title
   result.`vsync=`(vsync, silent=true)

--- a/tests/t_layershell.nim
+++ b/tests/t_layershell.nim
@@ -1,0 +1,31 @@
+when not defined(linux):
+  {.error: "wlr-layer-shell only works on Wayland (Linux)".}
+
+import std/[unittest]
+import siwin, opengl
+import siwin/platforms/wayland/[window, windowOpengl]
+
+test "wlr-layer-shell":
+  let window = newOpenglWindowWayland(
+    kind = WindowWaylandKind.LayerSurface, 
+    layer = Layer.Overlay 
+  )
+  loadExtensions()
+
+  window.setAnchor(LayerEdge.Left, 4)
+  window.setKeyboardInteractivity(LayerInteractivityMode.OnDemand)
+  window.setExclusiveZone(1)
+  window.run(
+    WindowEventsHandler(
+      onResize: proc(e: ResizeEvent) =
+        echo "resize"
+      ,
+      onRender: proc(e: RenderEvent) =
+        echo "render"
+        glClearColor 0.1, 0.1, 0.1, 1.0
+        glClear GlColorBufferBit or GlDepthBufferBit
+      ,
+      onKey: proc(e: KeyEvent) =
+        echo e.key
+    )
+  )


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bfb0dacd-d921-4377-9325-c68b45896bf3)

This PR adds experimental support for zwlr_layer_shell_v1 into Siwin, allowing for it to be used for making things like docks, wallpaper daemons and other neat little widgets for the compositors that support this protocol.

The Nim wrapper is written with help from GTK Layer Shell and Mako's code. If combined with Sigui, this'd be really neat! :^)