### PR TITLE
Fix/vulkan version

### DIFF
--- a/siwin.nimble
+++ b/siwin.nimble
@@ -12,8 +12,6 @@ requires "vmath >= 1.1.4"
 #       ask a userprogrammer to install specific platform dependencies if cross compiling.
 when defined(linux) or defined(bsd):
   requires "x11 >= 1.1"
-  requires "https://github.com/planetis-m/vulkan >= 1.3.295"
-  #requires "https://github.com/DanielBelmes/vulkan"
 
 when defined(windows):
   requires "winim >= 3.6"
@@ -30,7 +28,7 @@ feature "dev":
   requires "nimgl"
   requires "pixie"
   requires "sdl2"
-
+  requires "https://github.com/planetis-m/vulkan#b223dc9"
 
 
 when fileExists("src/siwin/build_utils/tasks.nim"):

--- a/siwin.nimble
+++ b/siwin.nimble
@@ -12,7 +12,7 @@ requires "vmath >= 1.1.4"
 #       ask a userprogrammer to install specific platform dependencies if cross compiling.
 when defined(linux) or defined(bsd):
   requires "x11 >= 1.1"
-  requires "https://github.com/planetis-m/vulkan#b223dc9"
+  requires "https://github.com/planetis-m/vulkan >= 1.3.295"
   #requires "https://github.com/DanielBelmes/vulkan"
 
 when defined(windows):


### PR DESCRIPTION
Removed strict vulkan version requirement that caused siwin installation conflicts (with app that use newer version). In siwin, vulkan library is only used for testing and doesn't affect siwin vulkan api logic 