### PR TITLE
Fix Cocoa horizontal scroll direction

### DIFF
--- a/src/siwin/platforms/cocoa/window.nim
+++ b/src/siwin/platforms/cocoa/window.nim
@@ -1448,7 +1448,9 @@ proc init =
             deltaY *= 0.1
   
           if abs(deltaX) > 0 or abs(deltaY) > 0:
-            window.eventsHandler.pushEvent onScroll, ScrollEvent(window: window, delta: deltaY, deltaX: deltaX)
+            window.eventsHandler.pushEvent onScroll, ScrollEvent(
+              window: window, delta: deltaY, deltaX: -deltaX
+            )
   
         addMethod "mouseDown:", proc(self: Id, cmd: Sel, event: NsEvent): Id {.cdecl.} =
           getWindow(self)


### PR DESCRIPTION
Committed as `d745838 Fix Cocoa horizontal scroll direction`. Worktree is clean.

Fixes Cocoa horizontal scroll direction by dispatching `ScrollEvent.deltaX` as the negated AppKit `scrollingDeltaX`.

Vertical scroll handling is unchanged.

## Rationale

AppKit already applies the user’s natural/classic scroll preference to `scrollingDeltaX` and `scrollingDeltaY`, so Siwin should not read or reapply that preference itself. This change is instead about matching Siwin’s cross-platform horizontal scroll sign convention.

SDL’s Cocoa backend follows the same axis mapping shape:

```c
x = -[event scrollingDeltaX];
y = [event scrollingDeltaY];
```

It separately tracks `isDirectionInvertedFromDevice`, which confirms that the X sign flip is a backend convention mapping, not natural-scroll preference handling.
