### PR TITLE
Fix X11 OpenGL popup windows

### DIFF
--- a/src/siwin/platforms/x11/windowOpengl.nim
+++ b/src/siwin/platforms/x11/windowOpengl.nim
@@ -29,7 +29,8 @@ proc `=destroy`(x: WindowX11OpenglObj) {.siwin_destructor.} =
 proc initOpenglWindow(
   window: WindowX11Opengl,
   size: IVec2, screen: ScreenX11,
-  fullscreen, frameless, transparent: bool, class: string
+  fullscreen, frameless, transparent: bool, class: string,
+  popupWindow = false
 ) =
   window.basicInitWindow size, screen
 
@@ -83,11 +84,18 @@ proc initOpenglWindow(
     discard window.globals.display.XMatchVisualInfo(window.screen, 24, TrueColor, vi.addr)
   
   let cmap = window.globals.display.XCreateColormap(root, vi.visual, AllocNone)
-  var swa = XSetWindowAttributes(colormap: cmap)
+  var swa = XSetWindowAttributes(
+    colormap: cmap,
+    override_redirect: if popupWindow: 1 else: 0,
+    save_under: if popupWindow: 1 else: 0
+  )
+  var valueMask = (CwColormap or CwEventMask or CwBorderPixel or CwBackPixel).culong
+  if popupWindow:
+    valueMask = valueMask or (CWOverrideRedirect or CWSaveUnder).culong
 
   window.handle = window.globals.display.XCreateWindow(
     root, 0, 0, size.x.cuint, size.y.cuint, 0, vi.depth, InputOutput, vi.visual,
-    CwColormap or CwEventMask or CwBorderPixel or CwBackPixel, swa.addr
+    valueMask, swa.addr
   )
 
   window.setupWindow fullscreen, frameless, class
@@ -148,3 +156,38 @@ proc newOpenglWindowX11*(
   result.title = title
   result.`vsync=`(vsync, silent=true)
   if not resizable: result.resizable = false
+
+proc newPopupWindowX11*(
+    globals: SiwinGlobalsX11,
+    parent: WindowX11Opengl,
+    placement: PopupPlacement,
+    transparent = false,
+    grab = true,
+): WindowX11Opengl =
+  if parent == nil:
+    raise ValueError.newException("Popup windows require a parent window")
+  new result
+  result.globals = globals
+  let screen = globals.defaultScreenX11()
+  result.initOpenglWindow(
+    placement.popupSize(),
+    screen,
+    fullscreen = false,
+    frameless = true,
+    transparent = transparent,
+    class = "",
+    popupWindow = true,
+  )
+  result.`vsync=`(parent.vsyncEnabled, silent = true)
+  result.initPopupState(parent, placement, grab)
+  let parentPos = globals.absolutePos(parent.handle)
+  let bounds = globals.popupConstraintBounds(parentPos + placement.anchorRectPos)
+  let rect = resolvePopupRect(
+    parentPos,
+    bounds.pos,
+    bounds.size,
+    placement,
+  )
+  if result.m_size != rect.size:
+    result.m_size = rect.size
+  result.pos = rect.pos

--- a/src/siwin/window.nim
+++ b/src/siwin/window.nim
@@ -12,6 +12,7 @@ when not siwin_use_lib:
   elif defined(linux) or defined(bsd):
     import ./platforms/x11/siwinGlobals as x11SiwinGlobals
     import ./platforms/x11/window as x11Window
+    import ./platforms/x11/windowOpengl as x11WindowOpengl
     import ./platforms/wayland/siwinGlobals as waylandSiwinGlobals
     import ./platforms/wayland/window as waylandWindow
 
@@ -130,7 +131,14 @@ when not siwin_use_lib:
       raise SiwinPlatformSupportDefect.newException("Popup windows are not supported on Android")
     elif defined(linux) or defined(bsd):
       if globals of SiwinGlobalsX11:
-        result = globals.SiwinGlobalsX11.newPopupWindowX11(parent.WindowX11, placement, transparent, grab)
+        if parent of WindowX11Opengl:
+          result = globals.SiwinGlobalsX11.newPopupWindowX11(
+            parent.WindowX11Opengl, placement, transparent, grab
+          )
+        else:
+          result = globals.SiwinGlobalsX11.newPopupWindowX11(
+            parent.WindowX11, placement, transparent, grab
+          )
       elif globals of SiwinGlobalsWayland:
         result = globals.SiwinGlobalsWayland.newPopupWindowWayland(parent.WindowWayland, placement, transparent, grab)
       else:

--- a/tests/tpopup_api.nim
+++ b/tests/tpopup_api.nim
@@ -3,10 +3,12 @@ import std/math
 import std/[os, osproc, strutils]
 import std/strtabs
 import pkg/vmath
-import siwin/[window, platforms]
+import siwin/[window, windowOpengl, platforms]
 
 when defined(macosx):
   import siwin/platforms/cocoa/window
+when defined(linux) or defined(bsd):
+  import siwin/platforms/x11/windowOpengl as x11WindowOpengl
 
 proc toPoints(distance: int32, scale: float32): int32 =
   if scale <= 0'f32:
@@ -317,3 +319,42 @@ suite "siwin popup api":
 
       close popup
       close parent
+
+    test "x11 popup from opengl parent keeps opengl window type":
+      if Platform.x11 notin availablePlatforms():
+        skip()
+
+      block runX11OpenglPopup:
+        let globals = newSiwinGlobals(Platform.x11)
+        var
+          parent: Window
+          popup: Window
+        try:
+          parent = globals.newOpenglWindow(
+            size = ivec2(300, 200), title = "opengl popup parent"
+          )
+        except CatchableError:
+          skip()
+          break runX11OpenglPopup
+
+        try:
+          require parent of x11WindowOpengl.WindowX11Opengl
+          parent.firstStep(makeVisible = false)
+          parent.step()
+
+          let placement = PopupPlacement(
+            anchorRectPos: ivec2(40, 48),
+            anchorRectSize: ivec2(96, 32),
+            size: ivec2(140, 110),
+            anchor: bottomLeft,
+            gravity: topLeft,
+            offset: ivec2(0, 14),
+          )
+          popup = globals.newPopupWindow(parent, placement, grab = true)
+
+          check popup of x11WindowOpengl.WindowX11Opengl
+        finally:
+          if not popup.isNil:
+            close popup
+          if not parent.isNil:
+            close parent


### PR DESCRIPTION
More X11 fixes. This fixes popupwindows + opengl on x11:

- Preserve the OpenGL window type when creating X11 popup
    windows from an OpenGL parent.

- Add an X11 OpenGL popup constructor that creates a popup
    GLX window with popup-specific X11 flags.

- Add a regression test covering OpenGL parent -> OpenGL
    popup behavior.

