### PR TITLE
Support OpenGL live resize content preservation on macOS

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -77,7 +77,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/nim-lang/nimble "$RUNNER_TEMP/nimble-head"
         cd "$RUNNER_TEMP/nimble-head"
-        git submodule update --init
+        git submodule update --init --recursive
         nim c --cc:vcc -d:release -o:"$HOME/.nimble/bin/nimble-head.exe" src/nimble.nim
         echo "NIMBLE_BIN=$HOME/.nimble/bin/nimble-head.exe" >> $GITHUB_ENV
 

--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -75,11 +75,12 @@ jobs:
     - name: Build Nimble (Windows)
       if: runner.os == 'Windows'
       run: |
-        git clone --depth 1 https://github.com/nim-lang/nimble "$RUNNER_TEMP/nimble-head"
-        cd "$RUNNER_TEMP/nimble-head"
-        git submodule update --init --recursive
-        nim c --cc:vcc -d:release -o:"$HOME/.nimble/bin/nimble-head.exe" src/nimble.nim
-        echo "NIMBLE_BIN=$HOME/.nimble/bin/nimble-head.exe" >> $GITHUB_ENV
+        mkdir -p "$RUNNER_TEMP/nimble"
+        curl --retry 3 -fsSL \
+          -o "$RUNNER_TEMP/nimble/nimble.zip" \
+          https://github.com/nim-lang/nimble/releases/download/v0.22.3/nimble-windows_x64.zip
+        unzip -q "$RUNNER_TEMP/nimble/nimble.zip" -d "$RUNNER_TEMP/nimble"
+        echo "NIMBLE_BIN=$RUNNER_TEMP/nimble/nimble.exe" >> $GITHUB_ENV
 
     - name: Tool Versions
       run: |

--- a/src/siwin/build_utils/tasks.nim
+++ b/src/siwin/build_utils/tasks.nim
@@ -59,7 +59,7 @@ task installTestDeps, "install test dependencies":
   exec "nimble install pixie"
 
 
-const testTargets = ["t_opengl_es", "t_opengl", "t_swrendering", "t_multiwindow", "t_vulkan", "t_offscreen"]
+const testTargets = ["t_opengl_es", "t_opengl", "t_swrendering", "t_multiwindow", "t_vulkan", "t_offscreen", "t_macos_live_resize"]
 
 proc shouldSkipTarget(target, args: string): bool =
   let targetingMacos =

--- a/src/siwin/platforms/any/window.nim
+++ b/src/siwin/platforms/any/window.nim
@@ -289,6 +289,7 @@ type
     m_minimized: bool
     m_visible: bool
     m_resizable: bool
+    m_preservesContentDuringLiveResize: bool
     m_minSize: IVec2
     m_maxSize: IVec2
 
@@ -433,6 +434,8 @@ proc maximized*(window: Window): bool = window.m_maximized
 proc minimized*(window: Window): bool = window.m_minimized
 proc visible*(window: Window): bool = window.m_visible
 proc resizable*(window: Window): bool = window.m_resizable
+proc preservesContentDuringLiveResize*(window: Window): bool =
+  window.m_preservesContentDuringLiveResize
 proc minSize*(window: Window): IVec2 = window.m_minSize
 proc maxSize*(window: Window): IVec2 = window.m_maxSize
 
@@ -517,6 +520,9 @@ method `visible=`*(window: Window, v: bool) {.base.} = discard
 
 method `resizable=`*(window: Window, v: bool) {.base.} = discard
   ## enable/disable resizing
+
+method `preservesContentDuringLiveResize=`*(window: Window, v: bool) {.base.} =
+  window.m_preservesContentDuringLiveResize = v
 
 method `minSize=`*(window: Window, v: IVec2) {.base.} = discard
   ## set minimum size

--- a/src/siwin/platforms/cocoa/window.nim
+++ b/src/siwin/platforms/cocoa/window.nim
@@ -20,6 +20,41 @@ template autoreleasepool(body: untyped) =
     pool.release()
 
 proc isFlipped(v: NSView): bool {.objc: "isFlipped".}
+proc layer(v: NSView): CALayer {.objc: "layer".}
+proc removeFromSuperview(v: NSView) {.objc: "removeFromSuperview".}
+proc setOpaque(window: NSWindow, opaque: BOOL) {.objc: "setOpaque:".}
+proc clearColor(cls: typedesc[NSColor]): NSColor {.objc: "clearColor".}
+proc setOpaque(layer: CALayer, opaque: BOOL) {.objc: "setOpaque:".}
+proc inLiveResize(view: NSView): bool {.objc: "inLiveResize".}
+proc getRectsExposedDuringLiveResize(
+  view: NSView, rects: ptr NSRect, count: ptr NSInteger
+) {.objc: "getRectsExposedDuringLiveResize:count:".}
+proc setNeedsDisplayInRect(view: NSView, rect: NSRect) {.objc: "setNeedsDisplayInRect:".}
+
+type
+  NSVisualEffectView = ptr object of NSView
+
+  NSVisualEffectMaterial {.size: sizeof(NSInteger).} = enum
+    NSVisualEffectMaterialAppearanceBased = 0
+    NSVisualEffectMaterialLight = 1
+    NSVisualEffectMaterialDark = 2
+    NSVisualEffectMaterialTitlebar = 3
+    NSVisualEffectMaterialPopover = 6
+    NSVisualEffectMaterialSidebar = 7
+    NSVisualEffectMaterialHUDWindow = 13
+
+  NSVisualEffectBlendingMode {.size: sizeof(NSInteger).} = enum
+    NSVisualEffectBlendingModeBehindWindow = 0
+    NSVisualEffectBlendingModeWithinWindow = 1
+
+  NSVisualEffectState {.size: sizeof(NSInteger).} = enum
+    NSVisualEffectStateFollowsWindowActiveState = 0
+    NSVisualEffectStateActive = 1
+    NSVisualEffectStateInactive = 2
+
+proc setMaterial(view: NSVisualEffectView, material: NSVisualEffectMaterial) {.objc: "setMaterial:".}
+proc setBlendingMode(view: NSVisualEffectView, mode: NSVisualEffectBlendingMode) {.objc: "setBlendingMode:".}
+proc setState(view: NSVisualEffectView, state: NSVisualEffectState) {.objc: "setState:".}
 
 type
   ScreenCocoa* = ref object of Screen
@@ -1331,9 +1366,35 @@ proc init =
         true
 
 
-    template addSiwinViewClass(className, superName: string, viewClassRef: untyped) =
+    template addSiwinViewClass(className, superName: string, viewClassRef: untyped, supportsLiveResizePreservation: static bool = false) =
       addClass className, superName, viewClassRef:
         addProtocol "NSTextInputClient"
+
+        when supportsLiveResizePreservation:
+          addMethod "preservesContentDuringLiveResize", proc(
+            self: Id, cmd: Sel
+          ): bool {.cdecl.} =
+            getWindow(self)
+            window.m_preservesContentDuringLiveResize
+
+          addMethod "setFrameSize:", proc(
+            self: Id, cmd: Sel, size: NSSize
+          ): Id {.cdecl.} =
+            discard callSuper(cast[NSObject](self), cmd, size)
+            getWindow(self)
+            if not window.m_preservesContentDuringLiveResize:
+              return
+
+            let view = cast[NSView](self)
+            if not view.inLiveResize():
+              return
+
+            var
+              rects: array[4, NSRect]
+              count: NSInteger
+            view.getRectsExposedDuringLiveResize(rects[0].addr, count.addr)
+            for i in 0 ..< count:
+              view.setNeedsDisplayInRect(rects[i])
         
         addMethod "acceptsFirstResponder", proc(self: Id, cmd: Sel): bool {.cdecl.} =
           true
@@ -1666,7 +1727,7 @@ proc init =
               # self.NSView.addCursorRect(self.NSView.bounds, cursor)
 
     addSiwinViewClass("SiwinViewSoftware", "NSImageView", softwareViewClass)
-    addSiwinViewClass("SiwinViewOpenGL", "NSOpenGLView", openglViewClass)
+    addSiwinViewClass("SiwinViewOpenGL", "NSOpenGLView", openglViewClass, true)
     addSiwinViewClass("SiwinViewMetal", "NSView", metalViewClass)
 
     NSApp.setDelegate(cast[NSObject](appDelegateClass.new))

--- a/tests/t_macos_live_resize.nim
+++ b/tests/t_macos_live_resize.nim
@@ -1,0 +1,36 @@
+import std/assertions
+
+when defined(macosx):
+  import pkg/vmath
+  import pkg/darwin/app_kit/nsview
+  import pkg/darwin/objc/runtime
+
+  import siwin
+  import siwin/platforms/cocoa/window
+
+  proc nativePreservesContentDuringLiveResize(
+    view: NSView
+  ): bool {.objc: "preservesContentDuringLiveResize".}
+
+  block macosOpenGlLiveResizePreservation:
+    let testWindow = newOpenglWindowCocoa(
+      size = ivec2(320, 240),
+      title = "siwin live resize preservation test",
+      vsync = false,
+    )
+    defer:
+      if testWindow.opened:
+        testWindow.close()
+
+    let view = cast[NSView](testWindow.nativeViewHandle())
+
+    doAssert not testWindow.preservesContentDuringLiveResize
+    doAssert not view.nativePreservesContentDuringLiveResize()
+
+    testWindow.preservesContentDuringLiveResize = true
+    doAssert testWindow.preservesContentDuringLiveResize
+    doAssert view.nativePreservesContentDuringLiveResize()
+
+    testWindow.preservesContentDuringLiveResize = false
+    doAssert not testWindow.preservesContentDuringLiveResize
+    doAssert not view.nativePreservesContentDuringLiveResize()


### PR DESCRIPTION
## Summary
- add a window option for preserving OpenGL content during macOS live resize
- redraw exposed regions while an opted-in OpenGL view is being live-resized
- cover the native AppKit property with a macOS regression test

## Testing
- `nim c --hints:off -r tests/t_macos_live_resize.nim`