### PR TITLE
Fix Cocoa modifier recovery and duplicate control input

### DIFF
--- a/src/siwin/platforms/cocoa/modifierstate.nim
+++ b/src/siwin/platforms/cocoa/modifierstate.nim
@@ -8,9 +8,12 @@ proc CGEventCreate(source: pointer): CGEventRef {.
   importc, header: "<CoreGraphics/CoreGraphics.h>".}
 proc CGEventGetFlags(event: CGEventRef): CGEventFlags {.
   importc, header: "<CoreGraphics/CoreGraphics.h>".}
+proc CGEventSourceKeyState(stateId: int32, keyCode: uint16): bool {.
+  importc, header: "<CoreGraphics/CoreGraphics.h>".}
 proc CFRelease(cf: pointer) {.importc, header: "<CoreFoundation/CoreFoundation.h>".}
 
 const
+  CgCombinedSessionState = 0'i32
   CgShiftMask = 0x00020000'u64
   CgCtrlMask = 0x00040000'u64
   CgAltMask = 0x00080000'u64
@@ -34,3 +37,6 @@ proc tryCurrentModifierState*(state: var set[ModifierKey]): bool =
   CFRelease(ev)
   state = modifierStateFromCgFlags(flags)
   true
+
+proc currentKeyPressed*(keyCode: uint16): bool =
+  CGEventSourceKeyState(CgCombinedSessionState, keyCode)

--- a/src/siwin/platforms/cocoa/window.nim
+++ b/src/siwin/platforms/cocoa/window.nim
@@ -1892,7 +1892,10 @@ proc init =
             Key.enter,
             Key.escape,
           }
-          if window.eventsHandler.onTextInput != nil and shouldRouteToInputContext:
+          let hasCommandModifier =
+            (modifiers * {ModifierKey.control, ModifierKey.system}).len > 0
+          if window.eventsHandler.onTextInput != nil and shouldRouteToInputContext and
+              not hasCommandModifier:
             var handledByInputContext = false
             let inputContext = cast[NSView](self).inputContext
             if inputContext != nil:

--- a/src/siwin/platforms/cocoa/window.nim
+++ b/src/siwin/platforms/cocoa/window.nim
@@ -593,6 +593,7 @@ proc refreshModifiers(window: WindowCocoa) =
     window.keyboard.modifiers = modifiers
 
 proc releaseAllInput(window: WindowCocoa) =
+  window.keyboard.modifiers = {}
   for key in window.keyboard.pressed:
     window.keyboard.pressed.excl key
     if window.eventsHandler.onKey != nil:
@@ -1917,17 +1918,22 @@ proc init =
             window.eventsHandler.pushEvent onKey, KeyEvent(window: window, key: key, pressed: false, repeated: false, modifiers: modifiers)  # todo: handle repeated
   
         addMethod "flagsChanged:", proc(self: Id, cmd: Sel, event: NsEvent): Id {.cdecl.} =
-          #? wtf is this?!?
           getWindow(self)
           let key = event.keyCode.keycodeToKey
           let modifiers = window.updateModifiers(event)
           if key != Key.unknown:
-            if key in window.keyboard.pressed:
-              window.keyboard.pressed.excl key
-              window.eventsHandler.pushEvent onKey, KeyEvent(window: window, key: key, pressed: false, repeated: false, modifiers: modifiers)  # todo: handle repeated
-            else:
+            let pressed = currentKeyPressed(event.keyCode)
+            if pressed:
               window.keyboard.pressed.incl key
-              window.eventsHandler.pushEvent onKey, KeyEvent(window: window, key: key, pressed: true, repeated: false, modifiers: modifiers)  # todo: handle repeated
+            else:
+              window.keyboard.pressed.excl key
+            window.eventsHandler.pushEvent onKey, KeyEvent(
+              window: window,
+              key: key,
+              pressed: pressed,
+              repeated: false,
+              modifiers: modifiers,
+            )
   
         addMethod "hasMarkedText", proc(self: Id, cmd: Sel): bool {.cdecl.} =
           getWindow(self)


### PR DESCRIPTION
## Summary

- derive Cocoa modifier key transitions from the current CoreGraphics per-key state instead of toggling cached state
- clear the modifier snapshot before emitting synthesized focus-loss releases
- keep Control and Command key chords out of the Cocoa text-input context so one physical chord cannot emit both key and text events
- recover correctly when an app regains focus while a modifier is already held, such as during Cmd-Tab

## Regression sequences

When the app became key while Command was held, refreshModifiers restored the generic modifier mask but the pressed-key set remained empty. The following Command release was therefore toggled into the pressed set as a new press, leaving Command stuck for later key events.

Cocoa also routed Control-letter chords through both the key event callback and NSTextInputClient. Terminal consumers therefore received control bytes such as Control-B and Control-F twice.

## Verification

- nim c --hints:off tests/t_multiwindow.nim
- nim c --hints:off tests/t_event_loop.nim
- downstream NimKit Bash input regression suite