### PR TITLE
Fix transparent X11 popup window creation

### DIFF
--- a/.github/workflows/build-full.yml
+++ b/.github/workflows/build-full.yml
@@ -54,7 +54,11 @@ jobs:
     - name: Install GrabNim
       if: runner.os != 'Windows'
       run: |
-        curl -fsSL https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh | sh
+        curl --fail --silent --show-error --location --http1.1 \
+          --retry 3 --retry-all-errors \
+          --output "$RUNNER_TEMP/grabnim-install.sh" \
+          https://codeberg.org/janAkali/grabnim/raw/branch/master/misc/install.sh
+        sh "$RUNNER_TEMP/grabnim-install.sh"
         echo "PATH=$HOME/.nimble/bin:$HOME/.local/share/grabnim/current/bin:$PATH" >> $GITHUB_ENV
 
     - name: Install Nim

--- a/src/siwin/build_utils/tasks.nim
+++ b/src/siwin/build_utils/tasks.nim
@@ -62,6 +62,7 @@ task installTestDeps, "install test dependencies":
 const testTargets = [
   "t_opengl_es", "t_opengl", "t_swrendering", "t_multiwindow", "t_vulkan",
   "t_offscreen", "t_macos_live_resize", "t_event_loop", "t_x11_size_hints",
+  "tpopup_api",
 ]
 
 proc shouldSkipTarget(target, args: string): bool =

--- a/src/siwin/platforms/winapi/window.nim
+++ b/src/siwin/platforms/winapi/window.nim
@@ -252,7 +252,7 @@ block winapiInit:
   wcex.lpszClassName = woClassName
   RegisterClassEx(wcex.addr)
 
-template pushEvent(eventsHandler: WindowEventsHandler, event, args) =
+template pushEvent*(eventsHandler: WindowEventsHandler, event, args) =
   if eventsHandler.event != nil:
     eventsHandler.event(args)
 

--- a/src/siwin/platforms/winapi/window.nim
+++ b/src/siwin/platforms/winapi/window.nim
@@ -232,7 +232,7 @@ proc windowProc(handle: HWnd, message: Uint, wParam: WParam, lParam: LParam): LR
 
 const
   wClassName = L"w"
-  woClassName = L"o"
+  woClassName* = L"o"
   dwmwaSystemBackdropType = 38.DWord
   dwmsbtNone = 1'i32
   dwmsbtTransientWindow = 3'i32

--- a/src/siwin/platforms/winapi/window.nim
+++ b/src/siwin/platforms/winapi/window.nim
@@ -326,7 +326,7 @@ method trySetBackdrop*(window: WindowWinapi, config: WindowBackdropConfig): bool
   true
 
 
-proc initWindow(
+proc initWindow*(
   window: WindowWinapi,
   size: IVec2,
   screen: ScreenWinapi,

--- a/src/siwin/platforms/x11/window.nim
+++ b/src/siwin/platforms/x11/window.nim
@@ -1731,19 +1731,21 @@ proc newPopupWindowX11*(
     let root = globals.display.DefaultRootWindow
 
     var vi: XVisualInfo
-    discard globals.display.XMatchVisualInfo(screen.id, 32, TrueColor, vi.addr)
+    if globals.display.XMatchVisualInfo(screen.id, 32, TrueColor, vi.addr) == 0:
+      raise OSError.newException("X11 does not provide a 32-bit TrueColor visual for transparent popup windows")
 
     let cmap = globals.display.XCreateColormap(root, vi.visual, AllocNone)
     var swa = XSetWindowAttributes(
       colormap: cmap,
       override_redirect: 1,
       save_under: 1,
+      border_pixel: 0,
     )
 
     result.handle = globals.display.XCreateWindow(
       root, 0, 0, placement.popupSize().x.cuint, placement.popupSize().y.cuint, 0,
       vi.depth, InputOutput, vi.visual,
-      CwColormap or CWOverrideRedirect or CWSaveUnder,
+      CwColormap or CWOverrideRedirect or CWSaveUnder or CWBorderPixel,
       swa.addr
     )
   else:

--- a/tests/tpopup_api.nim
+++ b/tests/tpopup_api.nim
@@ -164,6 +164,54 @@ when defined(linux) or defined(bsd):
       paramStr(1) == "--popup-runtime-helper":
     runPopupProbe(parseEnum[Platform](getEnv("SIWIN_POPUP_TEST_HELPER")))
 
+  proc checkX11PopupPlacement(transparent: bool) =
+    let globals = newSiwinGlobals(Platform.x11)
+    let parent =
+      globals.newSoftwareRenderingWindow(size = ivec2(300, 200), title = "popup parent")
+    parent.firstStep(makeVisible = false)
+    parent.step()
+
+    let placement = PopupPlacement(
+      anchorRectPos: ivec2(40, 48),
+      anchorRectSize: ivec2(96, 32),
+      size: ivec2(140, 110),
+      anchor: bottomLeft,
+      gravity: topLeft,
+      offset: ivec2(0, 14),
+    )
+    let popup = globals.newPopupWindow(parent, placement, transparent, grab = true)
+    popup.firstStep(makeVisible = false)
+    popup.stepUntil(
+      proc(): bool =
+        popup.pos == parent.pos + placement.popupRelativePos() and
+          popup.size == placement.popupSize()
+    )
+
+    check popup.pos == parent.pos + placement.popupRelativePos()
+    check popup.size == placement.popupSize()
+    check popup.transparent == transparent
+
+    let updatedPlacement = PopupPlacement(
+      anchorRectPos: ivec2(120, 76),
+      anchorRectSize: ivec2(84, 28),
+      size: ivec2(120, 96),
+      anchor: topRight,
+      gravity: bottomRight,
+      offset: ivec2(-6, -8),
+    )
+    popup.reposition(updatedPlacement)
+    popup.stepUntil(
+      proc(): bool =
+        popup.pos == parent.pos + updatedPlacement.popupRelativePos() and
+          popup.size == updatedPlacement.popupSize()
+    )
+
+    check popup.pos == parent.pos + updatedPlacement.popupRelativePos()
+    check popup.size == updatedPlacement.popupSize()
+
+    close popup
+    close parent
+
 suite "siwin popup api":
   test "popup placement resolves size and relative position":
     let placement = PopupPlacement(
@@ -269,56 +317,15 @@ suite "siwin popup api":
       check maxAbsComponent(waylandResult.relPos - x11Result.relPos) <= 1
       check maxAbsComponent(waylandResult.reportedSize - x11Result.reportedSize) <= 1
 
-    test "x11 popup window position matches relative placement in unconstrained case":
+    test "opaque x11 popup window position matches relative placement":
       if Platform.x11 notin availablePlatforms():
         skip()
+      checkX11PopupPlacement(transparent = false)
 
-      let globals = newSiwinGlobals(Platform.x11)
-      let parent = globals.newSoftwareRenderingWindow(
-        size = ivec2(300, 200), title = "popup parent"
-      )
-      parent.firstStep(makeVisible = false)
-      parent.step()
-
-      let placement = PopupPlacement(
-        anchorRectPos: ivec2(40, 48),
-        anchorRectSize: ivec2(96, 32),
-        size: ivec2(140, 110),
-        anchor: bottomLeft,
-        gravity: topLeft,
-        offset: ivec2(0, 14),
-      )
-      let popup = globals.newPopupWindow(parent, placement, grab = true)
-      popup.firstStep(makeVisible = false)
-      popup.stepUntil(
-        proc(): bool =
-          popup.pos == parent.pos + placement.popupRelativePos() and
-            popup.size == placement.popupSize()
-      )
-
-      check popup.pos == parent.pos + placement.popupRelativePos()
-      check popup.size == placement.popupSize()
-
-      let updatedPlacement = PopupPlacement(
-        anchorRectPos: ivec2(120, 76),
-        anchorRectSize: ivec2(84, 28),
-        size: ivec2(120, 96),
-        anchor: topRight,
-        gravity: bottomRight,
-        offset: ivec2(-6, -8),
-      )
-      popup.reposition(updatedPlacement)
-      popup.stepUntil(
-        proc(): bool =
-          popup.pos == parent.pos + updatedPlacement.popupRelativePos() and
-            popup.size == updatedPlacement.popupSize()
-      )
-
-      check popup.pos == parent.pos + updatedPlacement.popupRelativePos()
-      check popup.size == updatedPlacement.popupSize()
-
-      close popup
-      close parent
+    test "transparent x11 popup window position matches relative placement":
+      if Platform.x11 notin availablePlatforms():
+        skip()
+      checkX11PopupPlacement(transparent = true)
 
     test "x11 popup from opengl parent keeps opengl window type":
       if Platform.x11 notin availablePlatforms():


### PR DESCRIPTION
Transparent X11 popups could fail with `BadMatch` during `XCreateWindow`: the 32-bit child inherited the root’s border pixmap because `border_pixel` was omitted from the attribute mask. Set an explicit zero border pixel, include `CWBorderPixel`, and fail clearly when no 32-bit TrueColor visual is available.

The popup test now covers both opaque and transparent X11 software popups and is included in the legacy test task, so Linux CI runs it under its depth-24 Xvfb. This also exports the WinAPI base initializer used by the OpenGL and Vulkan window modules after the upstream incremental-compilation import cleanup.

Validation: `atlas-run tests tpopup_api --no-shuffle`; `atlas-run tests --compile-only --no-shuffle` (14/14).

Fixes the X11 menu-popup crash reported at https://forum.nim-lang.org/t/14136#85813.